### PR TITLE
Windows look for recent files in desktop/documents

### DIFF
--- a/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
+++ b/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
@@ -27,5 +27,4 @@ platforms:
   windows:
     psh:
       command: >
-        (Get-ChildItem -Path c:\pstbak\*.* -Filter *.pst | ? {$_.LastWriteTime
-        -gt (Get-Date).AddDays(-1)}).Count
+        (Get-ChildItem -Path $env:USERPROFILE\Desktop,$env:USERPROFILE\Documents -recurse | ? {-not $_.PSIsContainer -and $_.LastWriteTime -gt (Get-Date).AddDays(-1)}).FullName


### PR DESCRIPTION
Updated the "Find Recent Files" TTP to use this command since it will work on more systems out of the box (as opposed to looking in c:\pstbak) and it also returns the filenames so they can be parsed and used in subsequent TTPs