### PR TITLE
TTP to display kernel info from last system boot

### DIFF
--- a/discovery/19d4a157-b388-44ff-9597-e61bfc44a3e7.yml
+++ b/discovery/19d4a157-b388-44ff-9597-e61bfc44a3e7.yml
@@ -1,0 +1,21 @@
+id: 19d4a157-b388-44ff-9597-e61bfc44a3e7
+metadata:
+  version: 1
+  authors: 
+    - Abhishek S (abhiabhi2306)
+  tags: []
+name: Display last system boot information
+description: |
+  This will display all the information including error logs, bootloader module debug messages etc during the last system boot.
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  darwin:
+    sh:
+      command: dmseg
+  linux:
+    sh:
+      command: dmesg
+  

--- a/discovery/19d4a157-b388-44ff-9597-e61bfc44a3e7.yml
+++ b/discovery/19d4a157-b388-44ff-9597-e61bfc44a3e7.yml
@@ -4,17 +4,14 @@ metadata:
   authors: 
     - Abhishek S (abhiabhi2306)
   tags: []
-name: Display last system boot information
+name: Print kernel diagnostic information
 description: |
-  This will display all the information including error logs, bootloader module debug messages etc during the last system boot.
+      Prints the kernel diagnostic message buffer which includes bootloader information, debug messages, and more, from the current system boot.
 tactic: discovery
 technique:
   id: T1082
   name: System Information Discovery
 platforms:
-  darwin:
-    sh:
-      command: dmseg
   linux:
     sh:
       command: dmesg


### PR DESCRIPTION
  This will display all the information including error logs, bootloader module debug messages etc during the last system boot.