### PR TITLE
Adding TTP to find sudo binaries.

### DIFF
--- a/discovery/a7e937ee-ae32-455d-bd78-a8950757c703.yml
+++ b/discovery/a7e937ee-ae32-455d-bd78-a8950757c703.yml
@@ -4,9 +4,9 @@ metadata:
   authors:
     - Varun
   tags: []
-name: List sudo binaries under a user.
+name: List sudo binaries under a user
 description: |
-  All binaries which can run with sudo permissions will be listed.
+  All binaries which can run with sudo permissions will be listed
 tactic: discovery
 technique:
   id: T1082


### PR DESCRIPTION
sudo -l can be used to find binaries with sudo permission.