### PR TITLE
proposed fix to not break linux searches

### DIFF
--- a/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
+++ b/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
@@ -26,7 +26,7 @@ platforms:
   linux:
     sh:
       command: |
-        find ~ -mtime -1
+        find /home -mtime 1 -not -path '*/\.*'
   windows:
     psh:
       command: >


### PR DESCRIPTION
Current Linux version just hangs on nearly any computer. This version limits the search to the /home directory and excludes hidden directories/files.