### PR TITLE
fixing translators

### DIFF
--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -2,20 +2,20 @@ translators:
   metadata:
     description: Extra Operator listening posts for redirectors
     build: |
-      tar zcf DST.PATH/ftp.tar.gz SRC.PATH/ftp && tar zcf DST.PATH/grpc.tar.gz SRC.PATH/grpc
+      tar zcf DST.PATH/ftp.tar.gz -C SRC.PATH ftp && tar zcf DST.PATH/grpc.tar.gz -C SRC.PATH grpc
   payloads:
     ftp.tar.gz:
       install: |
         mkdir -p /tmp/translators && \
         curl 'PAYLOAD.URL' > /tmp/translators/ftp.tar.gz && \
-        tar zcf /tmp/translators/ftp.tar.gz /tmp/translators && \
+        tar xzf /tmp/translators/ftp.tar.gz -C /tmp/translators && \
         sudo pip3 install -r /tmp/translators/ftp/requirements.txt && \
         nohup sudo python3 /tmp/translators/ftp/server.py &
     grpc.tar.gz:
       install: |
         mkdir -p /tmp/translators && \
         curl 'PAYLOAD.URL' > /tmp/translators/grpc.tar.gz && \
-        tar zcf /tmp/translators/grpc.tar.gz /tmp/translators && \
+        tar xzf /tmp/translators/grpc.tar.gz -C /tmp/translators && \
         sudo pip3 install -r /tmp/translators/grpc/requirements.txt && \
         nohup sudo python3 /tmp/translators/grpc/server.py &
 


### PR DESCRIPTION
translators need to be compressed without their full path information and then extracted correctly.

the updated build step will create archives that when extracted will only prefix the contents with "ftp/" and "grpc/" for each of the two ftp and grpc translator tarballs respectively, while the updated install commands will actually use extraction flags and do so into the proper directories (rather than attempting to select the path inside the tar files which was breaking before).