### PR TITLE
adding Operator headless API as a payload

### DIFF
--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -104,6 +104,8 @@ team:
   metadata:
     description: Headless Opeator API / Team Server
     purpose: redirector
+    required: team
+    default: team
     build: |
       cp SRC.PATH/headless-linux DST.PATH
   payloads:

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -111,4 +111,4 @@ team:
   payloads:
     headless:
       install: |
-        curl "PAYLOAD.URL" > /tmp/headless && chmod +x /tmp/headless && ssh-keygen -t rsa -f /tmp/ssh_key -q -N "" && nohup sudo /tmp/headless --sessionToken "TOOL.PSK" --sshKey "/tmp/ssh_key" &
+        curl "PAYLOAD.URL" > /tmp/headless/bin && chmod +x /tmp/headless/bin && ssh-keygen -t rsa -f /tmp/headless/ssh_key -q -N "" && nohup sudo /tmp/headless/bin --sessionToken "TOOL.PSK" --sshKey "/tmp/headless/ssh_key" &

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -102,7 +102,7 @@ ctf:
 
 team:
   metadata:
-    description: Headless Opeator API / Team Server
+    description: Headless Operator API / Team Server
     purpose: redirector
     required: team
     default: team

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -107,8 +107,8 @@ team:
     required: team
     default: team
     build: |
-      cp SRC.PATH/headless-linux DST.PATH
+      cp SRC.PATH/headless-linux DST.PATH/headless
   payloads:
-    headless-linux:
+    headless:
       install: |
         curl "PAYLOAD.URL" > /tmp/headless && chmod +x /tmp/headless && ssh-keygen -t rsa -f /tmp/ssh_key -q -N "" && nohup sudo /tmp/headless --sessionToken "TOOL.PSK" --sshKey "/tmp/ssh_key" &

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -109,4 +109,4 @@ team:
   payloads:
     headless-linux:
       install: |
-        curl "PAYLOAD.URL" > /tmp/headless && chmod +x /tmp/headless && nohup sudo /tmp/headless --sessionToken "TOOL.PSK" &
+        curl "PAYLOAD.URL" > /tmp/headless && chmod +x /tmp/headless && ssh-keygen -t rsa -f /tmp/ssh_key -q -N "" && nohup sudo /tmp/headless --sessionToken=TOOL.PSK --sshKey=/tmp/ssh_key &

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -106,8 +106,7 @@ team:
     purpose: redirector
     required: team
     default: team
-    build: |
-      cp SRC.PATH/headless-linux DST.PATH/headless
+    download: https://download.prelude.org/latest?platform=darwin&variant=dmg&mode=headless
   payloads:
     headless:
       install: |

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -109,4 +109,4 @@ team:
   payloads:
     headless-linux:
       install: |
-        curl "PAYLOAD.URL" > /tmp/headless && chmod +x /tmp/headless && ssh-keygen -t rsa -f /tmp/ssh_key -q -N "" && nohup sudo /tmp/headless --sessionToken=TOOL.PSK --sshKey=/tmp/ssh_key &
+        curl "PAYLOAD.URL" > /tmp/headless && chmod +x /tmp/headless && ssh-keygen -t rsa -f /tmp/ssh_key -q -N "" && nohup sudo /tmp/headless --sessionToken "TOOL.PSK" --sshKey "/tmp/ssh_key" &

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -107,7 +107,7 @@ team:
     required: team
     default: team
     download:
-      headless: https://download.prelude.org/latest?platform=darwin&variant=dmg&mode=headless
+      headless: https://s3.amazonaws.com/operator.payloads.open/payloads/team/headless-linux
   payloads:
     headless:
       install: |

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -99,3 +99,14 @@ ctf:
   payloads:
     vulnerable.sh:
       install: curl 'PAYLOAD.URL' > tmp/vulnerable.sh && chmod +x /tmp/vulnerable.sh && sudo ./vulnerable.sh
+
+team:
+  metadata:
+    description: Headless Opeator API / Team Server
+    purpose: redirector
+    build: |
+      cp SRC.PATH/headless-linux DST.PATH
+  payloads:
+    headless-linux:
+      install: |
+        curl "PAYLOAD.URL" > /tmp/headless && chmod +x /tmp/headless && nohup sudo /tmp/headless --sessionToken "TOOL.PSK" &

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -106,7 +106,8 @@ team:
     purpose: redirector
     required: team
     default: team
-    download: https://download.prelude.org/latest?platform=darwin&variant=dmg&mode=headless
+    download:
+      headless: https://download.prelude.org/latest?platform=darwin&variant=dmg&mode=headless
   payloads:
     headless:
       install: |


### PR DESCRIPTION
this deprecates https://github.com/preludeorg/community/pull/196, extending it support the headless SSH server which will allow connected operator instances to initiate SSH tunnels so we can properly support reverse shells. In addition it also marks the Headless API as a "required" tool and marks it as the default for the `team` requirement group.

(this is still pending the final updated headless binary but should have all the necessary configs updated)

(see: https://github.com/preludeorg/professional/pull/131)