### PR TITLE
Fix TTP on Linux to correctly find recent files

### DIFF
--- a/ttps/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
+++ b/ttps/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
@@ -26,7 +26,7 @@ platforms:
   linux:
     sh:
       command: |
-        find /home -mtime 1 -not -path '*/\.*'
+        find /home -mtime -1 -not -path '*/\.*'
   windows:
     psh:
       command: >


### PR DESCRIPTION
On Linux, this TTP only found files that were **exactly** 24 hours old. The correction in the arguments ensures that it finds any files that are less than 24 hours old.