### PR TITLE
Logic to stay current with pneuma via outpost.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "payloads/src/pneuma"]
 	path = payloads/src/pneuma
 	url = git@github.com:preludeorg/pneuma.git
+	update = merge
+	checkout = master
 [submodule "payloads/src/nicodemus"]
 	path = payloads/src/nicodemus
 	url = git@github.com:preludeorg/nicodemus.git


### PR DESCRIPTION
By adding configuration here, the logic stays with the repo and isn't universal. In conjunction with https://github.com/preludeorg/outpost/pull/112