### PR TITLE
building community plugins and adding them as payloads

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "payloads/src/team/operator"]
 	path = payloads/src/team/operator
 	url = git@github.com:preludeorg/operator.git
+[submodule "payloads/src/plugins"]
+	path = payloads/src/plugins
+	url = git@github.com:preludeorg/plugins.git

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -123,8 +123,8 @@ plugins:
     purpose: plugin
     build: |
       npm install && npm run build && \
-      cp SRC.PATH/build/package/Editor/Editor.html DST.PATH/Editor.html && cp DST.PATH/Editor.html DST.PATH/../../plugins/Editor/Editor.html && \
-      cp SRC.PATH/build/package/Connect/Connect.html DST.PATH/Connect.html && cp DST.PATH/Connect.html DST.PATH/../../plugins/Connect/Connect.html
+      cp SRC.PATH/build/package/Editor/Editor.html DST.PATH/Editor.html && cp DST.PATH/Editor.html DST.PATH/../../../plugins/Editor/Editor.html && \
+      cp SRC.PATH/build/package/Connect/Connect.html DST.PATH/Connect.html && cp DST.PATH/Connect.html DST.PATH/../../../plugins/Connect/Connect.html
   payloads:
     Editor.html: {}
     Connect.html: {}

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -116,3 +116,15 @@ team:
     headless:
       install: |
         mkdir -p /tmp/headless && curl 'PAYLOAD.URL' > /tmp/headless/bin && chmod +x /tmp/headless/bin && ssh-keygen -t rsa -f /tmp/headless/ssh_key -q -N '' && nohup sudo /tmp/headless/bin --sessionToken 'TOOL.PSK' --sshKey /tmp/headless/ssh_key --hostName $(curl http://169.254.169.254/latest/meta-data/public-hostname) &
+
+plugins:
+  metadata:
+    description: Prelude Operator Community Plugins
+    purpose: plugins
+    build: |
+      npm install && npm run build && \
+      cp SRC.PATH/build/package/Editor/Editor.html DST.PATH/Editor.html && cp DST.PATH/Editor.html DST.PATH/../../plugins/Editor/Editor.html && \
+      cp SRC.PATH/build/package/Connect/Connect.html DST.PATH/Connect.html && cp DST.PATH/Connect.html DST.PATH/../../plugins/Connect/Connect.html
+  payloads:
+    Editor.html: {}
+    Connect.html: {}

--- a/payloads/config.yml
+++ b/payloads/config.yml
@@ -120,7 +120,7 @@ team:
 plugins:
   metadata:
     description: Prelude Operator Community Plugins
-    purpose: plugins
+    purpose: plugin
     build: |
       npm install && npm run build && \
       cp SRC.PATH/build/package/Editor/Editor.html DST.PATH/Editor.html && cp DST.PATH/Editor.html DST.PATH/../../plugins/Editor/Editor.html && \


### PR DESCRIPTION
leveraging our existing payload building capabilities to build the community plugins as payloads as well as copy them over to the plugins directory so we can refresh those autonomously too.