### PR TITLE
Add tag to all atomic red team procedures

### DIFF
--- a/plugins/ART/ART.html
+++ b/plugins/ART/ART.html
@@ -83,7 +83,7 @@
             id: ttp.auto_generated_guid,
             name: ttp.name,
             description: ttp.description,
-            metadata: {version: 1, authors: ['Atomic Red Team'], tags: [], source: 'Red Canary'},
+            metadata: {version: 1, authors: ['Atomic Red Team'], tags: ['ART'], source: 'Red Canary'},
             tactic: schema[data.attack_technique] || 'ART',
             technique: {id: data.attack_technique, name: data.display_name},
             platforms: {}


### PR DESCRIPTION
A small quality of life improvement. Makes it much easier to find ART procedures in the editor view.