### PR TITLE
Adding BOF support with Sliver plugin

### DIFF
--- a/plugins/Sliver/Sliver.js
+++ b/plugins/Sliver/Sliver.js
@@ -22,6 +22,7 @@ class mTLS extends Listener {
                 let self = this;
                 const sockets = new Set();
                 let opts = {};
+                debugger;
                 try {
                     opts = {
                         cert: fs.readFileSync(path.join(this.sliver.certificateDir, 'mtls-server-ca-cert.pem')),
@@ -54,7 +55,7 @@ class mTLS extends Listener {
                                     link.Status = response?.Status;
                                     link.Pid = response?.Pid;
                                 } else {
-                                    link.Response = JSON.stringify(response, null, 2);
+                                    link.Response = response;
                                     link.Status = status;
                                     link.Pid = sliverAgent.Pid;
                                 }
@@ -68,7 +69,7 @@ class mTLS extends Listener {
                                 let body = {};
                                 try {
                                     body = link.results(data);
-                                    recordResults(body, link.decode ? link.decode(body) : body, 0);
+                                    recordResults(body, link.decode(body), 0);
                                 } catch (e) {
                                     recordResults(body, 'Could not decode buffer message.', 1);
                                 }
@@ -76,11 +77,11 @@ class mTLS extends Listener {
 
                             const sendTask = (body) => {
                                 let task = self.sliver.buildEnvelope(link, body, operatorAgent.platform);
-                                socket.write(Buffer.concat([Buffer.from(self.toBytesInt32(task.length)), task]));
+                                socket.write(Buffer.concat([Buffer.from(mTLS.toBytesInt32(task.length)), task]));
                             }
 
                             if (self.checkForOperatorExecutor(link.Executor)) {
-                                sendTask(self.sliver.buildShellExecutor(link.Executor, link.Request));
+                                sendTask(link);
                             } else {
                                 let body = {};
                                 try { body = JSON.parse(link.Request); } catch (e) {}
@@ -103,7 +104,7 @@ class mTLS extends Listener {
                     let buff = new Buffer(0);
                     let size = 0;
                     socket.on('data', (data) => {
-                        if (data.length === 4) {
+                        if (data.length === 4 && size === 0) {
                             size = self.getSocketBeaconSize(data);
                         } else {
                             buff = Buffer.concat([buff, data]);
@@ -136,6 +137,7 @@ class mTLS extends Listener {
                                     });
                                 }
                                 buff = new Buffer(0);
+                                size = 0;
                             }
                         }
                     });
@@ -195,7 +197,7 @@ class mTLS extends Listener {
         }
         return new DataView(ab).getInt32(0, true);
     }
-    toBytesInt32 (num) {
+    static toBytesInt32 (num) {
         let arr = new ArrayBuffer(4);
         let view = new DataView(arr);
         view.setUint32(0, num, true);
@@ -222,36 +224,15 @@ class Sliver {
         this.#sliverpb = this.#loadProto('sliverpb', 'sliver.proto').sliverpb;
     }
     buildEnvelope(link, data, platform) {
-        const [req, resp, decode] = {...this.#executors, ...Sliver.#generateShellExecutorMap(platform)}[link.Executor];
+        const [req, resp, pack, decode] = {...this.#executors, ...this.#generateShellExecutorMap(platform)}[link.Executor];
         let callbacks = this.callbacks(req, resp);
         link['results'] = callbacks.resp;
-        if (decode) {
-            link['decode'] = decode;
-        }
+        link['decode'] = decode ? decode : (d) => JSON.stringify(d, null, 2);
         let env = this.#sliverpb.Envelope.create({
             Type: this.#messageTypes[`Msg${req}`],
-            Data: this.#sliverpb[req].encode(callbacks.req(data)).finish()
+            Data: this.#sliverpb[req].encode(callbacks.req(pack ? pack(data) : data)).finish()
         });
         return this.#sliverpb.Envelope.encode(env).finish();
-    }
-    buildShellExecutor(executor, request) {
-        let task = {Output: true}
-        switch (executor) {
-            case 'psh':
-                task = {...task, ...{Path: 'powershell.exe', Args: ['-execu', '-C', request]}};
-                break;
-            case 'cmd':
-                task = {...task, ...{Path: 'cmd.exe', Args: ['/S', '/C', request]}};
-                break;
-            case 'exec':
-                let args = request.split(' ');
-                task = {...task, ...{Path: args[0], Args: args.slice(1)}};
-                break;
-            default:
-                task = {...task, ...{Path: executor, Args: ['-c', request]}};
-                break;
-        }
-        return task;
     }
     unpackEnvelope(data) {
         return this.#sliverpb.Envelope.decode(data);
@@ -260,7 +241,7 @@ class Sliver {
         return this.#sliverpb[Object.keys(this.#messageTypes)[type - 1].split('Msg')[1]].decode(data);
     }
     executors(platform) {
-        return Object.keys(this.#executors).concat(Object.keys(Sliver.#generateShellExecutorMap(platform)));
+        return Object.keys(this.#executors).concat(Object.keys(this.#generateShellExecutorMap(platform)));
     }
     callbacks(req, resp) {
         const toObjOpts = {
@@ -287,15 +268,48 @@ class Sliver {
         })
         return root.loadSync(path.join(dir, proto)).root.nested;
     }
-    static #generateShellExecutorMap(platform) {
+    #generateShellExecutorMap(platform) {
         let executors = (platform === 'windows') ? ['cmd', 'psh', 'exec'] : ['sh', 'bash', 'zsh', 'exec'];
-        return executors.reduce((acc, executor) => ({...acc, [executor]: ['ExecuteReq', 'Execute', (d) => {d.Stdout = atob(d.Stdout); d.Stderr = atob(d.Stderr); return d;}]}), {})
+        return executors.reduce((acc, executor) => ({...acc, [executor]: ['ExecuteReq', 'Execute', (p) => Sliver.#buildShellExecutor(p.Executor, p.Request), (d) => {d.Stdout = atob(d.Stdout); d.Stderr = atob(d.Stderr); return d;}]}), {})
+    }
+    static #buildShellExecutor(executor, request) {
+        let task = {Output: true}
+        switch (executor) {
+            case 'psh':
+                task = {...task, ...{Path: 'powershell.exe', Args: ['-execu', '-C', request]}};
+                break;
+            case 'cmd':
+                task = {...task, ...{Path: 'cmd.exe', Args: ['/S', '/C', request]}};
+                break;
+            case 'exec':
+                let args = request.split(' ');
+                task = {...task, ...{Path: args[0], Args: args.slice(1)}};
+                break;
+            default:
+                task = {...task, ...{Path: executor, Args: ['-c', request]}};
+                break;
+        }
+        return task;
     }
     static #generateExecutorMap() {
+        // format: [ sliverpb request name, sliverpb response name, pack function (pre-process data), decode function (post-process data) ]
         return {
             envinfo: ['EnvInfo', 'EnvInfo'],
             unsetenv: ['UnsetEnvReq', 'UnsetEnv'],
-            'execute-assembly': ['InvokeExecuteAssemblyReq', 'ExecuteAssembly', (d) => {d.Output = atob(d.Output); return d;}],
+            'execute-assembly': ['InvokeExecuteAssemblyReq', 'ExecuteAssembly', null, (d) => atob(d.Output)],
+            bof: ['CallExtensionReq', 'CallExtension', (p) => {
+                    const addInt = (num) => {let buf = new Buffer(4); buf.writeUInt32LE(num); return buf;};
+                    const addShort = (num) => {let buf = new Buffer(2); buf.writeUInt16LE(num); return buf;};
+                    const addData = (buf) => Buffer.concat([Buffer.from(mTLS.toBytesInt32(buf.length)), Buffer.from(buf)]);
+                    const addString = (str) => Buffer.concat([Buffer.from(mTLS.toBytesInt32(str.length+1)), Buffer.from(str), new Buffer(1)]);
+                    const addWString = (str) => {
+                        let buf = Buffer.from(Buffer.concat([Buffer.from(str,  'utf16le'), new Buffer(1)]));
+                        Buffer.concat([Buffer.from(mTLS.toBytesInt32(buf.length+1)), buf]);
+                    };
+                    const args = {"int": addInt, "short": addShort, "string": addString, "wstring": addWString};
+                    p.Args = addData(Buffer.concat([addString('go'), addData(p.Args), addData(addData(Buffer.concat(p?.arguments ? p.arguments.map(arg => args[arg?.type](arg?.value)) : [new Buffer(4)])))]));
+                    return p;
+                }, (d) => atob(d.Output)],
             task: ['TaskReq', 'Task'],
             'execute-token': ['ExecuteTokenReq', 'Execute'],
             sideload: ['SideloadReq', 'Sideload'],
@@ -324,6 +338,7 @@ class Sliver {
             registrysubkeyslist: ['RegistrySubKeysListReq', 'RegistrySubKeysList'],
             registryread: ['RegistryReadReq', 'RegistryRead'],
             registrywrite: ['RegistryWriteReq', 'RegistryWrite'],
+            registerextension: ['RegisterExtensionReq', 'RegisterExtension']
         }
     }
     static #generateMessageConstants() {
@@ -458,10 +473,8 @@ Events.bus.on('plugin:delete', Object.assign((name) => {
 
 Requests.fetchOperator(`/v1/plugin/${PLUGIN_NAME}`, {method: 'GET'}).then(res => res.json()).then(config => {
     Promise.all([
-        'https://raw.githubusercontent.com/preludeorg/community/f78d4227d94a05b92875a70a082327819baf9067/plugins/Sliver/proto/commonpb/common.proto',
-        'https://raw.githubusercontent.com/preludeorg/community/f78d4227d94a05b92875a70a082327819baf9067/plugins/Sliver/proto/sliverpb/sliver.proto'
-        //'https://raw.githubusercontent.com/preludeorg/community/master/plugins/Sliver/proto/commonpb/common.proto',
-        //'https://raw.githubusercontent.com/preludeorg/community/master/plugins/Sliver/proto/sliverpb/sliver.proto'
+        'https://raw.githubusercontent.com/preludeorg/community/master/plugins/Sliver/proto/commonpb/common.proto',
+        'https://raw.githubusercontent.com/preludeorg/community/master/plugins/Sliver/proto/sliverpb/sliver.proto'
     ].map(url => fetch(url).then(res => res.text())))
         .then(texts => {
             const listener = new mTLS(config);

--- a/plugins/Sliver/Sliver.js
+++ b/plugins/Sliver/Sliver.js
@@ -22,7 +22,6 @@ class mTLS extends Listener {
                 let self = this;
                 const sockets = new Set();
                 let opts = {};
-                debugger;
                 try {
                     opts = {
                         cert: fs.readFileSync(path.join(this.sliver.certificateDir, 'mtls-server-ca-cert.pem')),

--- a/ttps/command-and-control/06543a80-1b92-4281-ac8d-cb59f6c708a4.yml
+++ b/ttps/command-and-control/06543a80-1b92-4281-ac8d-cb59f6c708a4.yml
@@ -1,0 +1,19 @@
+id: 06543a80-1b92-4281-ac8d-cb59f6c708a4
+name: Register COFF loader
+description: |
+  Install a COFF loader extension in the target Sliver agent.
+tactic: command-and-control
+technique:
+  id: T1105
+  name: Ingress Tool Transfer
+metadata:
+  authors:
+    - khyberspache
+  tags: []
+  payloads:
+    COFFLoader.x64.dll: c63af2b0a0a95cb7bff819a2cda481abab48ad07
+platforms:
+  windows:
+    registerextension:
+      command: '{"Name":"coff-loader", "Data":"PAYLOAD.BYTES", "OS":"windows", "Init":""}'
+      payload: COFFLoader.x64.dll

--- a/ttps/discovery/0f84eff4-f698-47cd-820f-2230471accfe.yml
+++ b/ttps/discovery/0f84eff4-f698-47cd-820f-2230471accfe.yml
@@ -1,0 +1,19 @@
+id: 0f84eff4-f698-47cd-820f-2230471accfe
+name: List user CACLs for file
+description: |
+  Lists users permissions for the target file(s).
+tactic: discovery
+technique:
+  id: T1083
+  name: File and Directory Discovery
+metadata:
+  authors:
+    - khyberspache
+  tags: []
+  payloads:
+    cacls.x64.o: 9aaaa58fc2bebb2cdf54a40ff26ad2d4bccea149
+platforms:
+  windows:
+    bof:
+      command: '{"Name":"coff-loader", "ServerStore":false, "Args":"PAYLOAD.BYTES", "Export":"LoadAndRun", "arguments": [{"type": "string", "value": "#{file.path}"}]}'
+      payload: cacls.x64.o

--- a/ttps/discovery/85341c8c-4ecb-4579-8f53-43e3e91d7617.yml
+++ b/ttps/discovery/85341c8c-4ecb-4579-8f53-43e3e91d7617.yml
@@ -7,6 +7,8 @@ metadata:
   tags:
   - APT29 Scenario 1
   - APT29
+  payloads:
+    arp.x64.o: 2868d2ed68c281c9878e7b8bdc505eb467abc490
 name: Collect ARP details
 description: |
   ARP is a protocol used to map IP addresses to the hardware addresses. This procedure runs a scan to identify which
@@ -23,3 +25,6 @@ platforms:
   windows:
     cmd:
       command: arp -a
+    bof:
+      command: '{"Name":"coff-loader", "ServerStore":false, "Args":"PAYLOAD.BYTES", "Export":"LoadAndRun"}'
+      payload: arp.x64.o


### PR DESCRIPTION
1. Adds BOF support to Sliver plugin
2. Adds an optional Pre-processing (pack) and Post-processing (Decode) step for each TTP/task
3. Shuffle some code around
4. Fix bug with small output sizes (< 4)
5. Adds 3 new TTPS:
    - Registering the COFF loader
    - ARP via BOF
    - Check CACLs via BOF

<img width="1612" alt="CleanShot 2022-03-03 at 00 15 33@2x" src="https://user-images.githubusercontent.com/43142871/156500929-f4e66f4d-3533-42e4-8975-5ab5692852af.png">
