### PR TITLE
Flattening keyword executors, making exit work for all agents

### DIFF
--- a/ttps/command-and-control/23c5cb2f-3f6f-4770-b260-13edf23f5903.yml
+++ b/ttps/command-and-control/23c5cb2f-3f6f-4770-b260-13edf23f5903.yml
@@ -12,23 +12,23 @@ technique:
   name: 'Encrypted Channel: Symmetric Cryptography'
 platforms:
   windows:
-    keyword:
-      command: 'config.{"Contact": "udp", "Address": "#{operator.udp}"}'
+    config:
+      command: '{"Contact": "udp", "Address": "#{operator.udp}"}'
       variants:
-      - command: 'config.{"Contact": "tcp", "Address": "#{operator.tcp}"}'
-      - command: 'config.{"Contact": "http", "Address": "#{operator.http}"}'
-      - command: 'config.{"Contact": "grpc", "Address": "#{operator.grpc}"}'
+      - command: '{"Contact": "tcp", "Address": "#{operator.tcp}"}'
+      - command: '{"Contact": "http", "Address": "#{operator.http}"}'
+      - command: '{"Contact": "grpc", "Address": "#{operator.grpc}"}'
   darwin:
-    keyword:
-      command: 'config.{"Contact": "udp", "Address": "#{operator.udp}"}'
+    config:
+      command: '{"Contact": "udp", "Address": "#{operator.udp}"}'
       variants:
-      - command: 'config.{"Contact": "tcp", "Address": "#{operator.tcp}"}'
-      - command: 'config.{"Contact": "http", "Address": "#{operator.http}"}'
-      - command: 'config.{"Contact": "grpc", "Address": "#{operator.grpc}"}'
+      - command: '{"Contact": "tcp", "Address": "#{operator.tcp}"}'
+      - command: '{"Contact": "http", "Address": "#{operator.http}"}'
+      - command: '{"Contact": "grpc", "Address": "#{operator.grpc}"}'
   linux:
-    keyword:
-      command: 'config.{"Contact": "udp", "Address": "#{operator.udp}"}'
+    config:
+      command: '{"Contact": "udp", "Address": "#{operator.udp}"}'
       variants:
-      - command: 'config.{"Contact": "tcp", "Address": "#{operator.tcp}"}'
-      - command: 'config.{"Contact": "http", "Address": "#{operator.http}"}'
-      - command: 'config.{"Contact": "grpc", "Address": "#{operator.grpc}"}'
+      - command: '{"Contact": "tcp", "Address": "#{operator.tcp}"}'
+      - command: '{"Contact": "http", "Address": "#{operator.http}"}'
+      - command: '{"Contact": "grpc", "Address": "#{operator.grpc}"}'

--- a/ttps/command-and-control/f2440a34-d2d8-41b2-b8d4-5eb468ac506c.yml
+++ b/ttps/command-and-control/f2440a34-d2d8-41b2-b8d4-5eb468ac506c.yml
@@ -8,9 +8,10 @@ technique:
   name: Non-Application Layer Protocol
 platforms:
   global:
-    keyword:
-      command: shell.["#{operator.tcp_shell}"]
+    shell:
+      command: '{"Target":"#{operator.tcp_shell}"}'
 metadata:
   authors:
   - khyberspache
   tags: []
+  chains: []

--- a/ttps/defense-evasion/03aa0a55-5052-4c02-909e-7d244f3083e1.yml
+++ b/ttps/defense-evasion/03aa0a55-5052-4c02-909e-7d244f3083e1.yml
@@ -12,5 +12,5 @@ technique:
   name: Execution Guardrails
 platforms:
   global:
-    keyword:
-      command: exit
+    exit:
+      command: '{"Force":true}'


### PR DESCRIPTION
- Exit keyword now will be identical across our agents + Sliver
- https://github.com/preludeorg/pneuma/pull/108