### PR TITLE
supporting login from command line

### DIFF
--- a/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
+++ b/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
@@ -23,5 +23,5 @@ platforms:
         curl #{payload.url} > /tmp/headless/bin && 
         chmod +x /tmp/headless/bin && 
         ssh-keygen -t rsa -f /tmp/headless/ssh_key -q -N '' && 
-        nohup sudo /tmp/headless/bin --sessionToken '#{operator.session}' --sshKey /tmp/headless/ssh_key --hostName $(curl http://169.254.169.254/latest/meta-data/public-hostname) >/tmp/headless/headless.log 2>&1  &
+        nohup sudo /tmp/headless/bin --sessionToken '#{operator.session}' --accountEmail '#{operator.login.email}' --accountToken '#{operator.login.token}' --accountSecret '#{operator.login.secret}' --sshKey /tmp/headless/ssh_key --hostName $(curl http://169.254.169.254/latest/meta-data/public-hostname) >/tmp/headless/headless.log 2>&1  &
       payload: headless


### PR DESCRIPTION
even though i still prefer not to do this, this stack of changes should automatically login to your provisioning users account when deploying redirectors

https://github.com/preludeorg/operator/pull/3344
https://github.com/preludeorg/headquarters/pull/1246