### PR TITLE
change single to escaped double quotes

### DIFF
--- a/docs/operator/advanced/api.md
+++ b/docs/operator/advanced/api.md
@@ -43,15 +43,15 @@ curl -X GET -sk -H "Authorization: $TOKEN" "https://localhost:8888/v1/chain/File
 #### Create a new chain
 
 ```bash
-curl -X POST -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' "https://localhost:8888/v1/chain" -d '{
-    "name": "my_new_adversary",
-    "ttps": [
-        "5c4dd985-89e3-4590-9b57-71fed66ff4e2",
-        "0cfcc788-b9e2-4c8c-a06b-8d365f33803e"
+curl -X POST -sk -H "Authorization: $TOKEN" -H "Content-Type: application/json" "https://localhost:8888/v1/chain" -d "{
+    \"name\": \"my_new_adversary\",
+    \"ttps\": [
+        \"5c4dd985-89e3-4590-9b57-71fed66ff4e2\",
+        \"0cfcc788-b9e2-4c8c-a06b-8d365f33803e\"
     ],
-    "summary": "A set of ttps that checks for user groups and identifies the users home directory",
-    "ordered": true
-}'
+    \"summary\": \"A set of ttps that checks for user groups and identifies the users home directory\",
+    \"ordered\": true
+}"
 ```
 
 #### Modify an existing chain
@@ -59,16 +59,16 @@ curl -X POST -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' 
 You can modify an existing chain by sending an updated chain body to the `/chain/YourChainID` endpoint:
 
 ```bash
-curl -X PUT -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' "https://localhost:8888/v1/chain/51154993-dabe-4999-94a9-9e81b781ecd8" -d '{
-    "name": "my_newer_adversary",
-    "ttps": [
-        "5c4dd985-89e3-4590-9b57-71fed66ff4e2",
-        "0cfcc788-b9e2-4c8c-a06b-8d365f33803e",
-        "b007fe0c-c6b0-4fda-915c-255bbc070de2"
+curl -X PUT -sk -H "Authorization: $TOKEN" -H "Content-Type: application/json" "https://localhost:8888/v1/chain/51154993-dabe-4999-94a9-9e81b781ecd8" -d "{
+    \"name\": \"my_newer_adversary\",
+    \"ttps\": [
+        \"5c4dd985-89e3-4590-9b57-71fed66ff4e2\",
+        \"0cfcc788-b9e2-4c8c-a06b-8d365f33803e\",
+        \"b007fe0c-c6b0-4fda-915c-255bbc070de2\"
     ],
-    "summary": "A set of ttps that checks for user groups, identifies the users home directory, and copies the clipboard",
-    "ordered": true
-}' | json_pp
+    \"summary\": \"A set of ttps that checks for user groups, identifies the users home directory, and copies the clipboard\",
+    \"ordered\": true
+}" | json_pp
 ```
 
 #### Delete a chain
@@ -84,10 +84,10 @@ curl -X DELETE -sk -H "Authorization: $TOKEN" "https://localhost:8888/v1/chain/5
 A cURL command for queueing an operation that runs the File Hunter chain against your home range. Note that the chainID is used (not name) in the URI:
 
 ```bash
-curl -X POST -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' "https://localhost:8888/v1/schedule" -d '{
-    "ranges": ["home"],
-    "ttps": ["90c2efaa-8205-480d-8bb6-61d90dbaf81b"], 
-    "ordered": false}'
+curl -X POST -sk -H "Authorization: $TOKEN" -H "Content-Type: application/json" "https://localhost:8888/v1/schedule" -d "{
+    \"ranges\": [\"home\"],
+    \"ttps\": [\"90c2efaa-8205-480d-8bb6-61d90dbaf81b\"], 
+    \"ordered\": false}"
 ```
 
 Alternatively, if you want to select individual agents, swap "ranges" for "agents" and pass in specific agent names.
@@ -97,11 +97,11 @@ Alternatively, if you want to select individual agents, swap "ranges" for "agent
 Using the schedule endpoint deploys the chain 10 seconds after the request is received. You can delay this by passing an epoch time that you want the chain to run.
 
 ```bash
-curl -X POST -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' "https://localhost:8888/v1/schedule" -d '{
-    "ranges": ["home"],
-    "ttps": ["90c2efaa-8205-480d-8bb6-61d90dbaf81b"],
-    "epoch": "1647441487467", 
-    "ordered": false}'
+curl -X POST -sk -H "Authorization: $TOKEN" -H "Content-Type: application/json" "https://localhost:8888/v1/schedule" -d "{
+    \"ranges\": [\"home\"],
+    \"ttps\": [\"90c2efaa-8205-480d-8bb6-61d90dbaf81b\"],
+    \"epoch\": \"1647441487467\", 
+    \"ordered\": false}"
 ```
 
 Alternatively, if you want to select individual agents, swap "ranges" for "agents" and pass in specific agent names.
@@ -129,10 +129,10 @@ curl -X GET -sk -H "Authorization: $TOKEN" "https://localhost:8888/v1/agent/test
 You can modify an existing agent by sending an updated agent body to the `/agent/YourAgentName` endpoint.
 
 ```bash
-curl -X PUT -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' "https://localhost:8888/v1/agent/test" -d '{
-    "range": "new_range",
-    "label": "new_agent_name"
-}' | json_pp
+curl -X PUT -sk -H "Authorization: $TOKEN" -H "Content-Type: application/json" "https://localhost:8888/v1/agent/test" -d "{
+    \"range\": \"new_range\",
+    \"label\": \"new_agent_name\"
+}" | json_pp
 ```
 
 #### Add multiple facts to an agent
@@ -140,7 +140,7 @@ curl -X PUT -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' "
 You can add multiple facts to a desired agent by passing a fact body to the `/agent/YourAgentName` endpoint.
 
 ```bash
-curl -X POST -sk -H "Authorization: $TOKEN" "https://localhost:8888/v1/agent/YourAgentName/facts" -d '[{"key":"hello", "value":"world", "scope":"agent"}, {"key":"fourth"}]' -H 'Content-Type: application/json'
+curl -X POST -sk -H "Authorization: $TOKEN" "https://localhost:8888/v1/agent/YourAgentName/facts" -d "[{\"key\":\"hello\", \"value\":\"world\", \"scope\":\"agent\"}, {\"key\":\"fourth\"}]" -H "Content-Type: application/json"
 ```
 
 ### TTPs
@@ -165,30 +165,30 @@ curl -X GET -sk -H "Authorization: $TOKEN" "https://localhost:8888/v1/ttp/ff9bbd
 Create a new TTP by posting a TTP body to the endpoint:
 
 ```bash
-curl -X POST -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' "https://localhost:8888/v1/ttp" -d '{
-    "id" : "ff9bbd7f-871e-4db4-bsdb-4e7a64a309bf",
-    "name" : "Who Dat",
-    "description" : "Get the current username",
-    "tactic" : "discovery",
-    "metadata" : {
-        "version" : 1,
-        "authors" : [
-            "bartimus"
+curl -X POST -sk -H "Authorization: $TOKEN" -H "Content-Type: application/json" "https://localhost:8888/v1/ttp" -d "{
+    \"id\" : \"ff9bbd7f-871e-4db4-bsdb-4e7a64a309bf\",
+    \"name\" : \"Who Dat\",
+    \"description\" : \"Get the current username\",
+    \"tactic\" : \"discovery\",
+    \"metadata\" : {
+        \"version\" : 1,
+        \"authors\" : [
+            \"bartimus\"
         ],
-        "tags" : []
+        \"tags\" : []
     },
-    "technique" : {
-        "id" : "T1082",
-        "name" : "System Information Discovery"
+    \"technique\" : {
+        \"id\" : \"T1082\",
+        \"name\" : \"System Information Discovery\"
     },
-    "platforms" : {
-        "darwin" : {
-            "sh" : {
-                "command" : "whoami"
+    \"platforms\" : {
+        \"darwin\" : {
+            \"sh\" : {
+                \"command\" : \"whoami\"
             }
         }
     }
-}'
+}"
 ```
 
 #### Modify a TTP in Operator
@@ -196,16 +196,16 @@ curl -X POST -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' 
 You can modify an existing TTP by sending an updated TTP body to the `/ttp/ttpID` endpoint.
 
 ```bash
-curl -X PUT -sk -H "Authorization: $TOKEN" -H 'Content-Type: application/json' "https://localhost:8888/v1/ttp/ff9bbd7f-871e-4db4-bsdb-4e7a64a309bf" -d '{
-    "name" : "Who is That",
-    "metadata" : {
-        "version" : 2,
-        "authors" : [
-            "bartimus"
+curl -X PUT -sk -H "Authorization: $TOKEN" -H "Content-Type: application/json" "https://localhost:8888/v1/ttp/ff9bbd7f-871e-4db4-bsdb-4e7a64a309bf" -d "{
+    \"name\" : \"Who is That\",
+    \"metadata\" : {
+        \"version\" : 2,
+        \"authors\" : [
+            \"bartimus\"
         ],
-        "tags" : []
+        \"tags\" : []
     }
-}'
+}"
 ```
 
 #### Delete a TTP in Operator


### PR DESCRIPTION
swapped single quotes in curl commands to escaped double quotes due to windows curl being bad

fix for: https://github.com/preludeorg/operator/issues/3410
