### PR TITLE
Major refactor to the ART plugin

### DIFF
--- a/plugins/ART/ART.js
+++ b/plugins/ART/ART.js
@@ -1,14 +1,22 @@
+const fetchOperator = (endpoint, options) => fetch(`https://${Settings.s.public.server}:${Settings.s.public.api}${endpoint}`, {
+            method: options.method,
+            body: options.body,
+            headers: {
+                ...options?.headers,
+                authorization: Settings.s.public.token
+            }
+        });
 const fetchARTRepoAllFiles = () => fetch(`https://api.github.com/repos/redcanaryco/atomic-red-team/git/trees/master?recursive=3`).then(res => res.json()).catch(console.log)
 const fetchArtRepoFile = (file) => fetch(`https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/${file}`).then(res => res.text()).catch(console.log)
 const fetchARTRepoIndexFile = () => fetchArtRepoFile('atomics/Indexes/index.yaml')
-const fetchGetOperatorARTFacts = () => Requests.local.fetchOperator('/v1/plugin/ART').then(res => res.json());
-const fetchPostOperatorARTFact = (facts) => fetchGetOperatorARTFacts().then(data => Requests.local.fetchOperator('/v1/plugin/ART', { method: 'POST', body: JSON.stringify(facts) }).then(res => res.json()));
-const fetchGetOperatorTTPs = () => Requests.local.fetchOperator('/v1/ttp').then(res => res.json());
-const fetchPostOperatorTTP = (ttp) => Requests.local.fetchOperator('/v1/ttp', { method: 'POST', body: JSON.stringify(ttp) }).then(res => res.json());
-const fetchDeleteARTTTP = (ttp) => Requests.local.fetchOperator(`/v1/ttp/${ttp.id}`, {method: 'DELETE'});
+const fetchGetOperatorARTFacts = () => fetchOperator('/v1/plugin/ART').then(res => res.json());
+const fetchPostOperatorARTFact = (facts) => fetchGetOperatorARTFacts().then(data => fetchOperator('/v1/plugin/ART', { method: 'POST', body: JSON.stringify(facts) }).then(res => res.json()));
+const fetchGetOperatorTTPs = () => fetchOperator('/v1/ttp').then(res => res.json());
+const fetchPostOperatorTTP = (ttp) => fetchOperator('/v1/ttp', { method: 'POST', body: JSON.stringify(ttp) }).then(res => res.json());
+const fetchDeleteARTTTP = (ttp) => fetchOperator(`/v1/ttp/${ttp.id}`, {method: 'DELETE'});
 const fetchHandleFacts = (facts, action='POST') => {
-  return Requests.local.fetchOperator('/v1/agent').then(res => res.json()).then(agents =>
-    Requests.local.fetchOperator(`/v1/agent/${agents[0].name}/facts`, {
+  return fetchOperator('/v1/agent').then(res => res.json()).then(agents =>
+    fetchOperator(`/v1/agent/${agents[0].name}/facts`, {
       method: action,
       body: JSON.stringify(Object.entries(facts).filter(([key, value]) => key.startsWith('art.')).map(([key, value]) => ({
         key: key, value: value, scope: 'global'

--- a/plugins/ART/ART.js
+++ b/plugins/ART/ART.js
@@ -56,8 +56,8 @@ const ingestAtomicRedTeamRepository = () => {
                         .catch(e => {})
       )).then(() =>
           Promise.all([
-              fetchPostOperatorARTFact(preludeFormattedData.facts).then(facts => fetchHandleFacts(facts)),
-              batchFetchTTPs(preludeFormattedData.procedures, fetchPostOperatorTTP)
+            fetchPostOperatorARTFact(preludeFormattedData.facts).then(facts => fetchHandleFacts(facts)),
+            batchFetchTTPs(preludeFormattedData.procedures, fetchPostOperatorTTP)
           ])
       ).then(resolve).catch(reject)
     })
@@ -139,8 +139,9 @@ const convertRedCanary = (data, schema) => {
 
 Events.bus.on('plugin:delete', Object.assign((name) => {
   if (name === 'ART') {
-    Promise.all([fetchGetOperatorARTFacts().then(facts => fetchHandleFacts(facts, 'DELETE')),
-    fetchGetOperatorTTPs()
+    Promise.all([
+      fetchGetOperatorARTFacts().then(facts => fetchHandleFacts(facts, 'DELETE')),
+      fetchGetOperatorTTPs()
     ]).then(([res, ttps]) => {
         const redCanaryTTPs = Object.values(ttps).filter(r => r?.metadata?.source === 'Red Canary');
         return Promise.resolve(batchFetchTTPs(redCanaryTTPs, fetchDeleteARTTTP))

--- a/plugins/ART/ART.js
+++ b/plugins/ART/ART.js
@@ -70,9 +70,9 @@ Requests.fetchOperator('/v1/ttp')
   .then(res => res.json())
   .then(res => {
     const ttps = Object.values(res).filter(r => r?.metadata?.source === 'Red Canary');
-    //if (!ttps.length) {
+    if (!ttps.length) {
       return ingestAtomicRedTeamRepository();
-    //}
+    }
   });
 
 const convertRedCanary = (data, schema) => {

--- a/plugins/ART/ART.js
+++ b/plugins/ART/ART.js
@@ -24,9 +24,7 @@ const batchFetchTTPs = (ttps, callback, batchSize=20, batchTimeout=250) => {
     const next = () => {
       if (idx < chunks.length) {
         Promise.all(chunks[idx++].map(ttp => callback(ttp)))
-            .then(() => {
-              setTimeout(next, batchTimeout)
-            }, reject)
+            .then(() => setTimeout(next, batchTimeout), reject)
       } else {
         resolve();
       }

--- a/plugins/ART/ART.js
+++ b/plugins/ART/ART.js
@@ -2,9 +2,9 @@ const fetchARTRepoAllFiles = () => fetch(`https://api.github.com/repos/redcanary
 const fetchArtRepoFile = (file) => fetch(`https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/${file}`).then(res => res.text())
 const fetchARTRepoIndexFile = () => fetchArtRepoFile('atomics/Indexes/index.yaml')
 const fetchGetOperatorARTFacts = () => Requests.fetchOperator('/v1/plugin/ART').then(res => res.json());
-const fetchUpdateOperatorARTFact = (facts) => fetchGetOperatorARTFacts().then(data => Requests.fetchOperator('/v1/plugin/ART', { method: 'POST', body: JSON.stringify(facts) }).then(res => res.json()));
+const fetchPostOperatorARTFact = (facts) => fetchGetOperatorARTFacts().then(data => Requests.fetchOperator('/v1/plugin/ART', { method: 'POST', body: JSON.stringify(facts) }).then(res => res.json()));
 const fetchGetOperatorTTPs = () => Requests.fetchOperator('/v1/ttp').then(res => res.json());
-const fetchUpdateOperatorTTP = (ttp) => Requests.fetchOperator('/v1/ttp', { method: 'POST', body: JSON.stringify(ttp) }).then(res => res.json());
+const fetchPostOperatorTTP = (ttp) => Requests.fetchOperator('/v1/ttp', { method: 'POST', body: JSON.stringify(ttp) }).then(res => res.json());
 const fetchDeleteARTTTP = (ttp) => Requests.fetchOperator(`/v1/ttp/${ttp.id}`, {method: 'DELETE'});
 const fetchHandleFacts = (facts, action='POST') => {
   return Requests.fetchOperator('/v1/agent').then(res => res.json()).then(agents =>
@@ -58,8 +58,8 @@ const ingestAtomicRedTeamRepository = () => {
                         .catch(e => {})
       )).then(() =>
           Promise.all([
-              fetchUpdateOperatorARTFact(preludeFormattedData.facts).then(facts => fetchHandleFacts(facts)),
-              batchFetchTTPs(preludeFormattedData.procedures, fetchUpdateOperatorTTP)
+              fetchPostOperatorARTFact(preludeFormattedData.facts).then(facts => fetchHandleFacts(facts)),
+              batchFetchTTPs(preludeFormattedData.procedures, fetchPostOperatorTTP)
           ])
       ).then(resolve).catch(reject)
     })

--- a/plugins/ART/ART.js
+++ b/plugins/ART/ART.js
@@ -1,14 +1,14 @@
 const fetchARTRepoAllFiles = () => fetch(`https://api.github.com/repos/redcanaryco/atomic-red-team/git/trees/master?recursive=3`).then(res => res.json()).catch(console.log)
-const fetchArtRepoFile = (file) => fetch(`https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/${file}`).then(res => res.text())
+const fetchArtRepoFile = (file) => fetch(`https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/${file}`).then(res => res.text()).catch(console.log)
 const fetchARTRepoIndexFile = () => fetchArtRepoFile('atomics/Indexes/index.yaml')
-const fetchGetOperatorARTFacts = () => Requests.fetchOperator('/v1/plugin/ART').then(res => res.json());
-const fetchPostOperatorARTFact = (facts) => fetchGetOperatorARTFacts().then(data => Requests.fetchOperator('/v1/plugin/ART', { method: 'POST', body: JSON.stringify(facts) }).then(res => res.json()));
-const fetchGetOperatorTTPs = () => Requests.fetchOperator('/v1/ttp').then(res => res.json());
-const fetchPostOperatorTTP = (ttp) => Requests.fetchOperator('/v1/ttp', { method: 'POST', body: JSON.stringify(ttp) }).then(res => res.json());
-const fetchDeleteARTTTP = (ttp) => Requests.fetchOperator(`/v1/ttp/${ttp.id}`, {method: 'DELETE'});
+const fetchGetOperatorARTFacts = () => Requests.local.fetchOperator('/v1/plugin/ART').then(res => res.json());
+const fetchPostOperatorARTFact = (facts) => fetchGetOperatorARTFacts().then(data => Requests.local.fetchOperator('/v1/plugin/ART', { method: 'POST', body: JSON.stringify(facts) }).then(res => res.json()));
+const fetchGetOperatorTTPs = () => Requests.local.fetchOperator('/v1/ttp').then(res => res.json());
+const fetchPostOperatorTTP = (ttp) => Requests.local.fetchOperator('/v1/ttp', { method: 'POST', body: JSON.stringify(ttp) }).then(res => res.json());
+const fetchDeleteARTTTP = (ttp) => Requests.local.fetchOperator(`/v1/ttp/${ttp.id}`, {method: 'DELETE'});
 const fetchHandleFacts = (facts, action='POST') => {
-  return Requests.fetchOperator('/v1/agent').then(res => res.json()).then(agents =>
-    Requests.fetchOperator(`/v1/agent/${agents[0].name}/facts`, {
+  return Requests.local.fetchOperator('/v1/agent').then(res => res.json()).then(agents =>
+    Requests.local.fetchOperator(`/v1/agent/${agents[0].name}/facts`, {
       method: action,
       body: JSON.stringify(Object.entries(facts).filter(([key, value]) => key.startsWith('art.')).map(([key, value]) => ({
         key: key, value: value, scope: 'global'

--- a/plugins/ART/ART.js
+++ b/plugins/ART/ART.js
@@ -66,8 +66,7 @@ const ingestAtomicRedTeamRepository = () => {
     .then(([data, index]) => resolveAllTTPFiles(data, index));
 };
 
-Requests.fetchOperator('/v1/ttp')
-  .then(res => res.json())
+fetchGetOperatorTTPs()
   .then(res => {
     const ttps = Object.values(res).filter(r => r?.metadata?.source === 'Red Canary');
     if (!ttps.length) {
@@ -144,8 +143,7 @@ const escapeTtpCommand = function(executor, command, replacements) {
 
 Events.bus.on('plugin:delete', Object.assign((name) => {
   if (name === 'ART') {
-    Requests.fetchOperator('/v1/ttp')
-      .then(res => res.json())
+    fetchGetOperatorTTPs()
       .then(res => {
         const ttps = Object.values(res).filter(r => r?.metadata?.source === 'Red Canary');
         return Promise.all(ttps.map(ttp =>


### PR DESCRIPTION
Breaks out ART plugin into a less optimal, but more coherent ingestion flow.

First we pull and process all ART data from GitHub. Once that is done, we then ingest the facts & TTPs. Ingestion is accomplished in batches w/ sleep intervals to avoid hammering the API with hundreds of requests.

depends on:
- https://github.com/preludeorg/operator/pull/3638