### PR TITLE
fixing regression with connect provisioning

### DIFF
--- a/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
+++ b/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
@@ -20,8 +20,7 @@ platforms:
     sh:
       command: |
         mkdir -p /tmp/headless && 
-        curl #{payload.url} > /tmp/headless/bin && 
+        curl "#{payload.url}" > /tmp/headless/bin && 
         chmod +x /tmp/headless/bin && 
-        ssh-keygen -t rsa -f /tmp/headless/ssh_key -q -N '' && 
-        nohup sudo /tmp/headless/bin --sessionToken '#{operator.session}' --sshKey /tmp/headless/ssh_key --hostName $(curl http://169.254.169.254/latest/meta-data/public-hostname) >/tmp/headless/headless.log 2>&1  &
+        nohup sudo /tmp/headless/bin --sessionToken '#{operator.session}' --accountEmail '#{operator.login.email}' --accountToken '#{operator.login.token}' --accountSecret '#{operator.login.secret}' >/tmp/headless/headless.log 2>&1  &
       payload: headless


### PR DESCRIPTION
this got broken again in https://github.com/preludeorg/community/commit/fb4f7a1aec501dcf52d780ad04f61ec17e85bd18, i'm not sure if the headless checksum should be updated at this point or not but the actual command block needs to be as above for things to work properly.

once this is in and deployed on our outposts, @stephanwampouille you should be able to test properly (though @jpmoss might need to bump the actual outposts for it to pick up).