### PR TITLE
updating plugin docs

### DIFF
--- a/docs/operator/plugins/https.md
+++ b/docs/operator/plugins/https.md
@@ -1,0 +1,11 @@
+# HTTPS plugin
+
+### What is HTTPS?
+
+---
+
+HTTPS is a plugin that supplies Operator with an additional agent listening post, for https, at port 8443. By default,
+Operator supports HTTP, TCP and UDP protocols.
+
+Once installed, you can point agents at https/8443. Expect this endpoint to behave like a typical API backed by 
+a self-signed certificate.

--- a/docs/operator/plugins/sliver.md
+++ b/docs/operator/plugins/sliver.md
@@ -1,5 +1,4 @@
-
-# Sliver Implant plugin
+# Sliver plugin
 
 ### What is Sliver?
 


### PR DESCRIPTION
Plugins should each come with a doc page.

Additionally, I've noted the port used by the HTTPS plugin, as our 1.5.3 build will likely not include the ability to configure it post-install.