### PR TITLE
new headless build location.

### DIFF
--- a/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
+++ b/ttps/resource-development/e22b3ca7-6181-49ca-ab14-52ff9b7f49be.yml
@@ -6,7 +6,7 @@ metadata:
   - connect
   - required
   payloads:
-    headless: cb01547d2ad40c544cfbb69e6f08158a312256eb
+    headless: 48edbbb38d51c6c68a52ca9049553f4de6bc272d
 name: Install Headless Operator
 description: |
   The Operator C2 can be run without a UI component. This allows deploying it as an API-only C2 on any Linux server.


### PR DESCRIPTION
New sha1sum for the new build. Headless does exist in this location, preemptively.