### PR TITLE
fix for training issue

### DIFF
--- a/training/introduction/advanced/9112f8d6-4ee1-4582-bd55-d42519cec783.yml
+++ b/training/introduction/advanced/9112f8d6-4ee1-4582-bd55-d42519cec783.yml
@@ -25,7 +25,7 @@ blocks:
     your payloads directory. Then Operator ships the TTP to the receiving agent, along with the URL of where to find the 
     payload. The agent makes an HTTP request back to Operator to download the payload before executing the TTP itself.
 answer:
-  script: 
-    let payload = Object.values(Attack.a).filter(function (a) {return a.name.toLowerCase() === 'hello world'})
+  script: |
+    let payload = Object.values(Attack.a).filter(function (a) {return a.name.toLowerCase() === 'hello world'});
     Number(payload[0].metadata.payloads["hello.txt"].length > 0)
   value: 1


### PR DESCRIPTION
This was missing a `|` and possibly a semi colon. Added in both to be extra sure.