### PR TITLE
have HTTPS/Sliver plugins listen to destroy:resource event

### DIFF
--- a/plugins/HTTPS/HTTPS.js
+++ b/plugins/HTTPS/HTTPS.js
@@ -33,14 +33,14 @@ class HTTPS extends HTTP {
 
 Listen.listeners.add(new HTTPS());
 
-Events.bus.on('plugin:delete', Object.assign((name) => {
-    if (name === 'HTTPS') {
+Events.bus.on('destroy:resource', Object.assign((resource, identifier) => {
+    if (resource == 'plugin' && identifier === 'HTTPS') {
         const listener = Listen.listeners.protocols.splice(Listen.listeners.protocols.findIndex(e => e.name === 'https'), 1);
         listener[0].destroy();
         delete Settings.s.public.ports.https;
-        Events.bus.listeners('plugin:delete').map(listener => {
+        Events.bus.listeners('destroy:resource').map(listener => {
             if (listener.HTTPS_LISTENER) {
-                Events.bus.off('plugin:delete', listener);
+                Events.bus.off('destroy:resource', listener);
             }
         });
     }

--- a/plugins/Sliver/Sliver.js
+++ b/plugins/Sliver/Sliver.js
@@ -485,14 +485,14 @@ Promise.all([
     Listen.listeners.add(listener);
  });
 
-Events.bus.on('plugin:delete', Object.assign((name) => {
-    if (name === 'Sliver') {
+Events.bus.on('destroy:resource', Object.assign((resource, identifier) => {
+    if (resource == 'plugin' && identifier === 'Sliver') {
         const listener = Listen.listeners.protocols.splice(Listen.listeners.protocols.findIndex(e => e.name === 'mtls'), 1);
         listener[0].destroy();
         delete Settings.s.public.ports.mtls;
-        Events.bus.listeners('plugin:delete').map(listener => {
+        Events.bus.listeners('destroy:resource').map(listener => {
             if (listener.SLIVER_LISTENER) {
-                Events.bus.off('plugin:delete', listener);
+                Events.bus.off('destroy:resource', listener);
             }
         });
     }


### PR DESCRIPTION
plugin:delete isn't emitted from operator, so switching from that even to destroy:resource

Art plugin is deprecated, so did not update that one